### PR TITLE
Flag lack of need for root access to enable faster Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,5 @@ go:
 
 install:
         - go get github.com/twpayne/go-kml
+
+sudo: false


### PR DESCRIPTION
See https://docs.travis-ci.com/user/migrating-from-legacy/