### PR TITLE
Abstract out Must and remove MustSetCoords

### DIFF
--- a/geom.go
+++ b/geom.go
@@ -115,6 +115,13 @@ func (l Layout) ZIndex() int {
 	}
 }
 
+func Must(g T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return g
+}
+
 var (
 	errIncorrectEnd         = errors.New("geom: incorrect end")
 	errLengthStrideMismatch = errors.New("geom: length/stride mismatch")

--- a/linearring.go
+++ b/linearring.go
@@ -33,9 +33,7 @@ func (lr *LinearRing) Length() float64 {
 }
 
 func (lr *LinearRing) MustSetCoords(coords []Coord) *LinearRing {
-	if err := lr.setCoords(coords); err != nil {
-		panic(err)
-	}
+	Must(lr.SetCoords(coords))
 	return lr
 }
 

--- a/linestring.go
+++ b/linestring.go
@@ -63,9 +63,7 @@ func (ls *LineString) Length() float64 {
 }
 
 func (ls *LineString) MustSetCoords(coords []Coord) *LineString {
-	if err := ls.setCoords(coords); err != nil {
-		panic(err)
-	}
+	Must(ls.SetCoords(coords))
 	return ls
 }
 

--- a/multilinestring.go
+++ b/multilinestring.go
@@ -44,9 +44,7 @@ func (mls *MultiLineString) LineString(i int) *LineString {
 }
 
 func (mls *MultiLineString) MustSetCoords(coords [][]Coord) *MultiLineString {
-	if err := mls.setCoords(coords); err != nil {
-		panic(err)
-	}
+	Must(mls.SetCoords(coords))
 	return mls
 }
 

--- a/multipoint.go
+++ b/multipoint.go
@@ -33,9 +33,7 @@ func (mp *MultiPoint) Length() float64 {
 }
 
 func (mp *MultiPoint) MustSetCoords(coords []Coord) *MultiPoint {
-	if err := mp.setCoords(coords); err != nil {
-		panic(err)
-	}
+	Must(mp.SetCoords(coords))
 	return mp
 }
 

--- a/multipolygon.go
+++ b/multipolygon.go
@@ -39,9 +39,7 @@ func (mp *MultiPolygon) Length() float64 {
 }
 
 func (mp *MultiPolygon) MustSetCoords(coords3 [][][]Coord) *MultiPolygon {
-	if err := mp.setCoords(coords3); err != nil {
-		panic(err)
-	}
+	Must(mp.SetCoords(coords3))
 	return mp
 }
 

--- a/multipolygon.go
+++ b/multipolygon.go
@@ -38,8 +38,8 @@ func (mp *MultiPolygon) Length() float64 {
 	return length3(mp.flatCoords, 0, mp.endss, mp.stride)
 }
 
-func (mp *MultiPolygon) MustSetCoords(coords3 [][][]Coord) *MultiPolygon {
-	Must(mp.SetCoords(coords3))
+func (mp *MultiPolygon) MustSetCoords(coords [][][]Coord) *MultiPolygon {
+	Must(mp.SetCoords(coords))
 	return mp
 }
 

--- a/point.go
+++ b/point.go
@@ -33,9 +33,7 @@ func (p *Point) Length() float64 {
 }
 
 func (p *Point) MustSetCoords(coords Coord) *Point {
-	if err := p.setCoords(coords); err != nil {
-		panic(err)
-	}
+	Must(p.SetCoords(coords))
 	return p
 }
 

--- a/polygon.go
+++ b/polygon.go
@@ -44,9 +44,7 @@ func (p *Polygon) LinearRing(i int) *LinearRing {
 }
 
 func (p *Polygon) MustSetCoords(coords [][]Coord) *Polygon {
-	if err := p.setCoords(coords); err != nil {
-		panic(err)
-	}
+	Must(p.SetCoords(coords))
 	return p
 }
 


### PR DESCRIPTION
This PR replaces `MustSetCoords` with an abstract function ` func Must(g T, err error) T` to which the return value of `SetCoords` can be used as an argument.

This has the advantage of extensibility: it is very likely that we'll add more functions that take a `T` and some other arguments in the future and return a new or updated `T` and an `error`. This saves us having to write a `MustDoFoo` convenience function for every `DoFoo` function that we write.

The downside here is that we're really suffering from Go's lack of generics and its primitive type system. Every call to `Must` strips type information, and this type information occasionally needs to be reinstated with a type assertion. Yuk.

@jesseeichar What do you think about this? Nice abstraction or too messy and complex for Go?