### PR TITLE
Optimize the performance of Marshal/Unmarshal for WKB

### DIFF
--- a/encoding/wkb/wkb_test.go
+++ b/encoding/wkb/wkb_test.go
@@ -236,6 +236,26 @@ func TestRandom(t *testing.T) {
 	}
 }
 
+func BenchmarkUnmarshal(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		for _, tc := range testdata.Random {
+			if _, err := Unmarshal(tc.WKB); err != nil {
+				b.Errorf("unmarshal error %v", err)
+			}
+		}
+	}
+}
+
+func BenchmarkMarshal(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		for _, tc := range testdata.Random {
+			if _, err := Marshal(tc.G, NDR); err != nil {
+				b.Errorf("marshal error %v", err)
+			}
+		}
+	}
+}
+
 func TestCrashes(t *testing.T) {
 	for _, tc := range []struct {
 		s    string

--- a/encoding/wkbcommon/binary.go
+++ b/encoding/wkbcommon/binary.go
@@ -1,0 +1,69 @@
+// Package wkbcommon contains code common to WKB and EWKB encoding.
+package wkbcommon
+
+import (
+	"encoding/binary"
+	"io"
+	"math"
+)
+
+func readFloat(buf []byte, byteOrder binary.ByteOrder) float64 {
+	u := byteOrder.Uint64(buf)
+	return math.Float64frombits(u)
+}
+
+func ReadUInt32(r io.Reader, byteOrder binary.ByteOrder) (uint32, error) {
+	var buf [4]byte
+	if _, err := io.ReadFull(r, buf[:]); err != nil {
+		return 0, err
+	}
+	return byteOrder.Uint32(buf[:]), nil
+}
+
+func ReadFloatArray(r io.Reader, byteOrder binary.ByteOrder, array []float64) error {
+	buf := make([]byte, 8*len(array))
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return err
+	}
+	// Convert to an array of floats
+	for i := range array {
+		array[i] = readFloat(buf[8*i:], byteOrder)
+	}
+	return nil
+}
+
+func ReadByte(r io.Reader) (byte, error) {
+	var buf [1]byte
+	if _, err := r.Read(buf[:]); err != nil {
+		return 0, err
+	}
+	return buf[0], nil
+}
+
+func writeFloat(buf []byte, byteOrder binary.ByteOrder, value float64) {
+	u := math.Float64bits(value)
+	byteOrder.PutUint64(buf, u)
+}
+
+func WriteFloatArray(w io.Writer, byteOrder binary.ByteOrder, array []float64) error {
+	buf := make([]byte, 8*len(array))
+	for i, f := range array {
+		writeFloat(buf[8*i:], byteOrder, f)
+	}
+	_, err := w.Write(buf)
+	return err
+}
+
+func WriteUInt32(w io.Writer, byteOrder binary.ByteOrder, value uint32) error {
+	var buf [4]byte
+	byteOrder.PutUint32(buf[:], value)
+	_, err := w.Write(buf[:])
+	return err
+}
+
+func WriteByte(w io.Writer, value byte) error {
+	var buf [1]byte
+	buf[0] = value
+	_, err := w.Write(buf[:])
+	return err
+}

--- a/encoding/wkbcommon/wkbcommon.go
+++ b/encoding/wkbcommon/wkbcommon.go
@@ -101,7 +101,7 @@ const (
 // ReadFlatCoords0 reads flat coordinates 0.
 func ReadFlatCoords0(r io.Reader, byteOrder binary.ByteOrder, stride int) ([]float64, error) {
 	coord := make([]float64, stride)
-	if err := binary.Read(r, byteOrder, &coord); err != nil {
+	if err := ReadFloatArray(r, byteOrder, coord); err != nil {
 		return nil, err
 	}
 	return coord, nil
@@ -109,15 +109,15 @@ func ReadFlatCoords0(r io.Reader, byteOrder binary.ByteOrder, stride int) ([]flo
 
 // ReadFlatCoords1 reads flat coordinates 1.
 func ReadFlatCoords1(r io.Reader, byteOrder binary.ByteOrder, stride int) ([]float64, error) {
-	var n uint32
-	if err := binary.Read(r, byteOrder, &n); err != nil {
+	n, err := ReadUInt32(r, byteOrder)
+	if err != nil {
 		return nil, err
 	}
 	if n > MaxGeometryElements[1] {
 		return nil, ErrGeometryTooLarge{Level: 1, N: n, Limit: MaxGeometryElements[1]}
 	}
 	flatCoords := make([]float64, int(n)*stride)
-	if err := binary.Read(r, byteOrder, &flatCoords); err != nil {
+	if err := ReadFloatArray(r, byteOrder, flatCoords); err != nil {
 		return nil, err
 	}
 	return flatCoords, nil
@@ -125,8 +125,8 @@ func ReadFlatCoords1(r io.Reader, byteOrder binary.ByteOrder, stride int) ([]flo
 
 // ReadFlatCoords2 reads flat coordinates 2.
 func ReadFlatCoords2(r io.Reader, byteOrder binary.ByteOrder, stride int) ([]float64, []int, error) {
-	var n uint32
-	if err := binary.Read(r, byteOrder, &n); err != nil {
+	n, err := ReadUInt32(r, byteOrder)
+	if err != nil {
 		return nil, nil, err
 	}
 	if n > MaxGeometryElements[2] {
@@ -147,20 +147,20 @@ func ReadFlatCoords2(r io.Reader, byteOrder binary.ByteOrder, stride int) ([]flo
 
 // WriteFlatCoords0 writes flat coordinates 0.
 func WriteFlatCoords0(w io.Writer, byteOrder binary.ByteOrder, coord []float64) error {
-	return binary.Write(w, byteOrder, coord)
+	return WriteFloatArray(w, byteOrder, coord)
 }
 
 // WriteFlatCoords1 writes flat coordinates 1.
 func WriteFlatCoords1(w io.Writer, byteOrder binary.ByteOrder, coords []float64, stride int) error {
-	if err := binary.Write(w, byteOrder, uint32(len(coords)/stride)); err != nil {
+	if err := WriteUInt32(w, byteOrder, uint32(len(coords)/stride)); err != nil {
 		return err
 	}
-	return binary.Write(w, byteOrder, coords)
+	return WriteFloatArray(w, byteOrder, coords)
 }
 
 // WriteFlatCoords2 writes flat coordinates 2.
 func WriteFlatCoords2(w io.Writer, byteOrder binary.ByteOrder, flatCoords []float64, ends []int, stride int) error {
-	if err := binary.Write(w, byteOrder, uint32(len(ends))); err != nil {
+	if err := WriteUInt32(w, byteOrder, uint32(len(ends))); err != nil {
 		return err
 	}
 	offset := 0


### PR DESCRIPTION
It turns out that using `binary.Read` and `binary.Write` is quite slow. Significant performance gains can be achieved by using `byteOrder.Uint64` and `byteOrder.PutUint64`.

Here are some benchmarks:

Before my change:
```
BenchmarkUnmarshal-4   	    5000       	    230946 ns/op       	  133568 B/op  	    2290 allocs/op
BenchmarkMarshal-4     	   10000       	    231463 ns/op       	   87008 B/op  	    1753 allocs/op
```
After my change:
```
BenchmarkUnmarshal-4   	   10000       	    140244 ns/op       	  120400 B/op  	    1542 allocs/op
BenchmarkMarshal-4     	   10000       	    117554 ns/op       	   73776 B/op  	    1005 allocs/op
```