### PR TITLE
Fix panic when a geojson.Geometry is decoded (via Geometry.Decode) wh…

### DIFF
--- a/encoding/geojson/geojson.go
+++ b/encoding/geojson/geojson.go
@@ -26,6 +26,13 @@ func (e ErrUnsupportedType) Error() string {
 	return fmt.Sprintf("geojson: unsupported type: %s", string(e))
 }
 
+// ErrInvalidInput is returned when the input is invalid
+type ErrInvalidInput struct{}
+
+func (e ErrInvalidInput) Error() string {
+	return fmt.Sprint("geojson: invalid input, couldn't retrieve coordinates")
+}
+
 // A Geometry is a geometry in GeoJSON format.
 type Geometry struct {
 	Type        string           `json:"type"`
@@ -95,6 +102,9 @@ func guessLayout3(coords3 [][][]geom.Coord) (geom.Layout, error) {
 
 // Decode decodes g to a geometry.
 func (g *Geometry) Decode() (geom.T, error) {
+	if g.Coordinates == nil {
+		return nil, ErrInvalidInput{}
+	}
 	switch g.Type {
 	case "Point":
 		var coords geom.Coord

--- a/encoding/geojson/geojson_test.go
+++ b/encoding/geojson/geojson_test.go
@@ -9,6 +9,17 @@ import (
 	"github.com/twpayne/go-geom"
 )
 
+func TestGeometryDecode_NilCoordinates(t *testing.T) {
+	geometry := Geometry{
+		Type:        "LineString",
+		Coordinates: nil,
+	}
+	if _, err := geometry.Decode(); err == nil {
+		t.Fatalf("Decode of Geometry with nil Coordinates didn't return an error even though we expected one")
+	}
+
+}
+
 func TestGeometry(t *testing.T) {
 	for _, tc := range []struct {
 		g geom.T


### PR DESCRIPTION
This fixes a panic when a `geojson.Geometry` is decoded (via `Geometry.Decode`) while `Geometry.Coordinates` is `nil`.

Also adds a test for this specific case.

Should fix #72.