### PR TITLE
Add query parameter to PostGIS integration test

### DIFF
--- a/encoding/ewkb/postgis_test.go
+++ b/encoding/ewkb/postgis_test.go
@@ -33,9 +33,14 @@ func TestPostGIS(t *testing.T) {
 		}
 	}
 
+	queryP := &ewkb.Polygon{
+		Polygon: geom.NewPolygon(geom.XY).MustSetCoords([][]geom.Coord{{
+			{4, 4}, {4, 0}, {8, 0}, {8, 4}, {4, 4},
+		}}),
+	}
 	var p ewkb.Polygon
-	if err := db.QueryRow("SELECT ST_AsEWKB(geom) FROM testgeoms;").Scan(&p); err != nil {
-		t.Errorf("db.QueryRow(...).Scan(...) == %v, want <nil>", err)
+	if err := db.QueryRow("SELECT ST_AsEWKB(geom) FROM testgeoms WHERE ST_Within(geom, $1);", queryP).Scan(&p); err != nil {
+		t.Fatalf("db.QueryRow(...).Scan(...) == %v, want <nil>", err)
 	}
 	if got, want := p.Coords(), [][]geom.Coord{{{5, 3}, {5, 0}, {7, 0}, {7, 3}, {5, 3}}}; !reflect.DeepEqual(got, want) {
 		t.Errorf("p.Coords() == %v, want %v", got, want)


### PR DESCRIPTION
Adds a query parameter to the PostGIS integration test to better illustrate #65.

Test currently fails. Can be fixed by appending `&binary_parameters=yes` to the connection string.

Without binary_parameters:
```
$ go test -tags integration -v postgis_test.go
=== RUN   TestPostGIS
--- FAIL: TestPostGIS (0.04s)
	postgis_test.go:43: db.QueryRow(...).Scan(...) == pq: invalid byte sequence for encoding "UTF8": 0x00, want <nil>
FAIL
exit status 1
FAIL	command-line-arguments	0.045s
```

With binary_parameters:
```
$ go test -tags integration -v postgis_test.go
=== RUN   TestPostGIS
--- PASS: TestPostGIS (0.04s)
PASS
ok  	command-line-arguments	0.052s
```
