### PR TITLE
Documentation improvements

### DIFF
--- a/flat_geom0.go
+++ b/flat_geom0.go
@@ -7,34 +7,43 @@ type geom0 struct {
 	srid       int
 }
 
+// Bounds returns the bounds of g.
 func (g *geom0) Bounds() *Bounds {
 	return NewBounds(g.layout).extendFlatCoords(g.flatCoords, 0, len(g.flatCoords), g.stride)
 }
 
+// Coords returns all the coordinates in g, i.e. a single coordinate.
 func (g *geom0) Coords() Coord {
 	return inflate0(g.flatCoords, 0, len(g.flatCoords), g.stride)
 }
 
+// Ends returns the end indexes of sub-structures of g, i.e. an empty slice.
 func (g *geom0) Ends() []int {
 	return nil
 }
 
+// Endss returns the end indexes of sub-sub-structures of g, i.e. an empty
+// slice.
 func (g *geom0) Endss() [][]int {
 	return nil
 }
 
+// FlatCoords returns the flat coordinates of g.
 func (g *geom0) FlatCoords() []float64 {
 	return g.flatCoords
 }
 
+// Layout returns g's layout.
 func (g *geom0) Layout() Layout {
 	return g.layout
 }
 
+// NumCoords returns the number of coordinates in g, i.e. 1.
 func (g *geom0) NumCoords() int {
 	return 1
 }
 
+// Reserve reserves space in g for n coordinates.
 func (g *geom0) Reserve(n int) {
 	if cap(g.flatCoords) < n*g.stride {
 		fcs := make([]float64, len(g.flatCoords), n*g.stride)
@@ -43,6 +52,7 @@ func (g *geom0) Reserve(n int) {
 	}
 }
 
+// SRID returns g's SRID.
 func (g *geom0) SRID() int {
 	return g.srid
 }
@@ -53,6 +63,7 @@ func (g *geom0) setCoords(coords0 []float64) error {
 	return err
 }
 
+// Stride returns g's stride.
 func (g *geom0) Stride() int {
 	return g.stride
 }

--- a/flat_geom1.go
+++ b/flat_geom1.go
@@ -4,14 +4,17 @@ type geom1 struct {
 	geom0
 }
 
+// Coord returns the ith coord of g.
 func (g *geom1) Coord(i int) Coord {
 	return g.flatCoords[i*g.stride : (i+1)*g.stride]
 }
 
+// Coords unpacks and returns all of g's coordinates.
 func (g *geom1) Coords() []Coord {
 	return inflate1(g.flatCoords, 0, len(g.flatCoords), g.stride)
 }
 
+// NumCoords returns the number of coordinates in g.
 func (g *geom1) NumCoords() int {
 	return len(g.flatCoords) / g.stride
 }

--- a/flat_geom2.go
+++ b/flat_geom2.go
@@ -5,10 +5,12 @@ type geom2 struct {
 	ends []int
 }
 
+// Coords returns all of g's coordinates.
 func (g *geom2) Coords() [][]Coord {
 	return inflate2(g.flatCoords, 0, g.ends, g.stride)
 }
 
+// Ends returns the end indexes of all sub-structures in g.
 func (g *geom2) Ends() []int {
 	return g.ends
 }

--- a/flat_geom3.go
+++ b/flat_geom3.go
@@ -5,10 +5,12 @@ type geom3 struct {
 	endss [][]int
 }
 
+// Coords returns all the coordinates in g.
 func (g *geom3) Coords() [][][]Coord {
 	return inflate3(g.flatCoords, 0, g.endss, g.stride)
 }
 
+// Endss returns a list of all the sub-sub-structures in g.
 func (g *geom3) Endss() [][]int {
 	return g.endss
 }

--- a/geometrycollection.go
+++ b/geometrycollection.go
@@ -13,21 +13,21 @@ func NewGeometryCollection() *GeometryCollection {
 	return &GeometryCollection{}
 }
 
-// Geom returns the ith geometry in gc.
-func (gc *GeometryCollection) Geom(i int) T {
-	return gc.geoms[i]
+// Geom returns the ith geometry in g.
+func (g *GeometryCollection) Geom(i int) T {
+	return g.geoms[i]
 }
 
-// Geoms returns the geometries in gc.
-func (gc *GeometryCollection) Geoms() []T {
-	return gc.geoms
+// Geoms returns the geometries in g.
+func (g *GeometryCollection) Geoms() []T {
+	return g.geoms
 }
 
-// Layout returns the smallest layout that covers all of the layouts in gc's
+// Layout returns the smallest layout that covers all of the layouts in g's
 // geometries.
-func (gc *GeometryCollection) Layout() Layout {
+func (g *GeometryCollection) Layout() Layout {
 	maxLayout := NoLayout
-	for _, g := range gc.geoms {
+	for _, g := range g.geoms {
 		switch l := g.Layout(); l {
 		case XYZ:
 			if maxLayout == XYM {
@@ -50,29 +50,29 @@ func (gc *GeometryCollection) Layout() Layout {
 	return maxLayout
 }
 
-// NumGeoms returns the number of geometries in gc.
-func (gc *GeometryCollection) NumGeoms() int {
-	return len(gc.geoms)
+// NumGeoms returns the number of geometries in g.
+func (g *GeometryCollection) NumGeoms() int {
+	return len(g.geoms)
 }
 
-// Stride returns the stride of gc's layout.
-func (gc *GeometryCollection) Stride() int {
-	return gc.Layout().Stride()
+// Stride returns the stride of g's layout.
+func (g *GeometryCollection) Stride() int {
+	return g.Layout().Stride()
 }
 
-// Bounds returns the bounds of all the geometries in gc.
-func (gc *GeometryCollection) Bounds() *Bounds {
+// Bounds returns the bounds of all the geometries in g.
+func (g *GeometryCollection) Bounds() *Bounds {
 	// FIXME this needs work for mixing layouts, e.g. XYZ and XYM
-	b := NewBounds(gc.Layout())
-	for _, g := range gc.geoms {
+	b := NewBounds(g.Layout())
+	for _, g := range g.geoms {
 		b = b.Extend(g)
 	}
 	return b
 }
 
 // Empty returns true if the collection is empty.
-func (gc *GeometryCollection) Empty() bool {
-	return len(gc.geoms) == 0
+func (g *GeometryCollection) Empty() bool {
+	return len(g.geoms) == 0
 }
 
 // FlatCoords panics.
@@ -90,27 +90,27 @@ func (*GeometryCollection) Endss() [][]int {
 	panic("Endss() called on a GeometryCollection")
 }
 
-// SRID returns gc's SRID.
-func (gc *GeometryCollection) SRID() int {
-	return gc.srid
+// SRID returns g's SRID.
+func (g *GeometryCollection) SRID() int {
+	return g.srid
 }
 
-// MustPush pushes gs to gc. It panics on any error.
-func (gc *GeometryCollection) MustPush(gs ...T) *GeometryCollection {
-	if err := gc.Push(gs...); err != nil {
+// MustPush pushes gs to g. It panics on any error.
+func (g *GeometryCollection) MustPush(gs ...T) *GeometryCollection {
+	if err := g.Push(gs...); err != nil {
 		panic(err)
 	}
-	return gc
+	return g
 }
 
 // Push appends geometries.
-func (gc *GeometryCollection) Push(gs ...T) error {
-	gc.geoms = append(gc.geoms, gs...)
+func (g *GeometryCollection) Push(gs ...T) error {
+	g.geoms = append(g.geoms, gs...)
 	return nil
 }
 
-// SetSRID sets gc's SRID and the SRID of all its elements.
-func (gc *GeometryCollection) SetSRID(srid int) *GeometryCollection {
-	gc.srid = srid
-	return gc
+// SetSRID sets g's SRID and the SRID of all its elements.
+func (g *GeometryCollection) SetSRID(srid int) *GeometryCollection {
+	g.srid = srid
+	return g
 }

--- a/linearring.go
+++ b/linearring.go
@@ -12,54 +12,54 @@ func NewLinearRing(layout Layout) *LinearRing {
 
 // NewLinearRingFlat returns a new LinearRing with the given flat coordinates.
 func NewLinearRingFlat(layout Layout, flatCoords []float64) *LinearRing {
-	lr := new(LinearRing)
-	lr.layout = layout
-	lr.stride = layout.Stride()
-	lr.flatCoords = flatCoords
-	return lr
+	g := new(LinearRing)
+	g.layout = layout
+	g.stride = layout.Stride()
+	g.flatCoords = flatCoords
+	return g
 }
 
 // Area returns the the area.
-func (lr *LinearRing) Area() float64 {
-	return doubleArea1(lr.flatCoords, 0, len(lr.flatCoords), lr.stride) / 2
+func (g *LinearRing) Area() float64 {
+	return doubleArea1(g.flatCoords, 0, len(g.flatCoords), g.stride) / 2
 }
 
 // Clone returns a deep copy.
-func (lr *LinearRing) Clone() *LinearRing {
-	return deriveCloneLinearRing(lr)
+func (g *LinearRing) Clone() *LinearRing {
+	return deriveCloneLinearRing(g)
 }
 
 // Empty returns false.
-func (lr *LinearRing) Empty() bool {
+func (g *LinearRing) Empty() bool {
 	return false
 }
 
 // Length returns the length of the perimeter.
-func (lr *LinearRing) Length() float64 {
-	return length1(lr.flatCoords, 0, len(lr.flatCoords), lr.stride)
+func (g *LinearRing) Length() float64 {
+	return length1(g.flatCoords, 0, len(g.flatCoords), g.stride)
 }
 
 // MustSetCoords sets the coordinates and panics if there is any error.
-func (lr *LinearRing) MustSetCoords(coords []Coord) *LinearRing {
-	Must(lr.SetCoords(coords))
-	return lr
+func (g *LinearRing) MustSetCoords(coords []Coord) *LinearRing {
+	Must(g.SetCoords(coords))
+	return g
 }
 
 // SetCoords sets the coordinates.
-func (lr *LinearRing) SetCoords(coords []Coord) (*LinearRing, error) {
-	if err := lr.setCoords(coords); err != nil {
+func (g *LinearRing) SetCoords(coords []Coord) (*LinearRing, error) {
+	if err := g.setCoords(coords); err != nil {
 		return nil, err
 	}
-	return lr, nil
+	return g, nil
 }
 
-// SetSRID sets the SRID of lr.
-func (lr *LinearRing) SetSRID(srid int) *LinearRing {
-	lr.srid = srid
-	return lr
+// SetSRID sets the SRID of g.
+func (g *LinearRing) SetSRID(srid int) *LinearRing {
+	g.srid = srid
+	return g
 }
 
-// Swap swaps the values of lr and lr2.
-func (lr *LinearRing) Swap(lr2 *LinearRing) {
-	*lr, *lr2 = *lr2, *lr
+// Swap swaps the values of g and g2.
+func (g *LinearRing) Swap(g2 *LinearRing) {
+	*g, *g2 = *g2, *g
 }

--- a/linestring.go
+++ b/linestring.go
@@ -14,91 +14,91 @@ func NewLineString(l Layout) *LineString {
 // NewLineStringFlat returns a new LineString with layout l and control points
 // flatCoords.
 func NewLineStringFlat(layout Layout, flatCoords []float64) *LineString {
-	ls := new(LineString)
-	ls.layout = layout
-	ls.stride = layout.Stride()
-	ls.flatCoords = flatCoords
-	return ls
+	g := new(LineString)
+	g.layout = layout
+	g.stride = layout.Stride()
+	g.flatCoords = flatCoords
+	return g
 }
 
-// Area returns the area of ls, i.e. zero.
-func (ls *LineString) Area() float64 {
+// Area returns the area of g, i.e. zero.
+func (g *LineString) Area() float64 {
 	return 0
 }
 
-// Clone returns a copy of ls that does not alias ls.
-func (ls *LineString) Clone() *LineString {
-	return deriveCloneLineString(ls)
+// Clone returns a copy of g that does not alias g.
+func (g *LineString) Clone() *LineString {
+	return deriveCloneLineString(g)
 }
 
 // Empty returns false.
-func (ls *LineString) Empty() bool {
+func (g *LineString) Empty() bool {
 	return false
 }
 
 // Interpolate returns the index and delta of val in dimension dim.
-func (ls *LineString) Interpolate(val float64, dim int) (int, float64) {
-	n := len(ls.flatCoords)
+func (g *LineString) Interpolate(val float64, dim int) (int, float64) {
+	n := len(g.flatCoords)
 	if n == 0 {
 		panic("geom: empty linestring")
 	}
-	if val <= ls.flatCoords[dim] {
+	if val <= g.flatCoords[dim] {
 		return 0, 0
 	}
-	if ls.flatCoords[n-ls.stride+dim] <= val {
-		return (n - 1) / ls.stride, 0
+	if g.flatCoords[n-g.stride+dim] <= val {
+		return (n - 1) / g.stride, 0
 	}
 	low := 0
-	high := n / ls.stride
+	high := n / g.stride
 	for low < high {
 		mid := (low + high) / 2
-		if val < ls.flatCoords[mid*ls.stride+dim] {
+		if val < g.flatCoords[mid*g.stride+dim] {
 			high = mid
 		} else {
 			low = mid + 1
 		}
 	}
 	low--
-	val0 := ls.flatCoords[low*ls.stride+dim]
+	val0 := g.flatCoords[low*g.stride+dim]
 	if val == val0 {
 		return low, 0
 	}
-	val1 := ls.flatCoords[(low+1)*ls.stride+dim]
+	val1 := g.flatCoords[(low+1)*g.stride+dim]
 	return low, (val - val0) / (val1 - val0)
 }
 
-// Length returns the length of ls.
-func (ls *LineString) Length() float64 {
-	return length1(ls.flatCoords, 0, len(ls.flatCoords), ls.stride)
+// Length returns the length of g.
+func (g *LineString) Length() float64 {
+	return length1(g.flatCoords, 0, len(g.flatCoords), g.stride)
 }
 
 // MustSetCoords is like SetCoords but it panics on any error.
-func (ls *LineString) MustSetCoords(coords []Coord) *LineString {
-	Must(ls.SetCoords(coords))
-	return ls
+func (g *LineString) MustSetCoords(coords []Coord) *LineString {
+	Must(g.SetCoords(coords))
+	return g
 }
 
-// SetCoords sets the coordinates of ls.
-func (ls *LineString) SetCoords(coords []Coord) (*LineString, error) {
-	if err := ls.setCoords(coords); err != nil {
+// SetCoords sets the coordinates of g.
+func (g *LineString) SetCoords(coords []Coord) (*LineString, error) {
+	if err := g.setCoords(coords); err != nil {
 		return nil, err
 	}
-	return ls, nil
+	return g, nil
 }
 
-// SetSRID sets the SRID of ls.
-func (ls *LineString) SetSRID(srid int) *LineString {
-	ls.srid = srid
-	return ls
+// SetSRID sets the SRID of g.
+func (g *LineString) SetSRID(srid int) *LineString {
+	g.srid = srid
+	return g
 }
 
 // SubLineString returns a LineString from starts at index start and stops at
-// index stop of ls. The returned LineString aliases ls.
-func (ls *LineString) SubLineString(start, stop int) *LineString {
-	return NewLineStringFlat(ls.layout, ls.flatCoords[start*ls.stride:stop*ls.stride])
+// index stop of g. The returned LineString aliases g.
+func (g *LineString) SubLineString(start, stop int) *LineString {
+	return NewLineStringFlat(g.layout, g.flatCoords[start*g.stride:stop*g.stride])
 }
 
-// Swap swaps the values of ls and ls2.
-func (ls *LineString) Swap(ls2 *LineString) {
-	*ls, *ls2 = *ls2, *ls
+// Swap swaps the values of g and g2.
+func (g *LineString) Swap(g2 *LineString) {
+	*g, *g2 = *g2, *g
 }

--- a/linestring.go
+++ b/linestring.go
@@ -21,7 +21,7 @@ func NewLineStringFlat(layout Layout, flatCoords []float64) *LineString {
 	return ls
 }
 
-// Area returns the length of ls, i.e. zero.
+// Area returns the area of ls, i.e. zero.
 func (ls *LineString) Area() float64 {
 	return 0
 }

--- a/multilinestring.go
+++ b/multilinestring.go
@@ -20,7 +20,7 @@ func NewMultiLineStringFlat(layout Layout, flatCoords []float64, ends []int) *Mu
 	return mls
 }
 
-// Area returns 0.
+// Area returns the area of mls, i.e. 0.
 func (mls *MultiLineString) Area() float64 {
 	return 0
 }

--- a/multilinestring.go
+++ b/multilinestring.go
@@ -12,79 +12,79 @@ func NewMultiLineString(layout Layout) *MultiLineString {
 
 // NewMultiLineStringFlat returns a new MultiLineString with the given flat coordinates.
 func NewMultiLineStringFlat(layout Layout, flatCoords []float64, ends []int) *MultiLineString {
-	mls := new(MultiLineString)
-	mls.layout = layout
-	mls.stride = layout.Stride()
-	mls.flatCoords = flatCoords
-	mls.ends = ends
-	return mls
+	g := new(MultiLineString)
+	g.layout = layout
+	g.stride = layout.Stride()
+	g.flatCoords = flatCoords
+	g.ends = ends
+	return g
 }
 
-// Area returns the area of mls, i.e. 0.
-func (mls *MultiLineString) Area() float64 {
+// Area returns the area of g, i.e. 0.
+func (g *MultiLineString) Area() float64 {
 	return 0
 }
 
 // Clone returns a deep copy.
-func (mls *MultiLineString) Clone() *MultiLineString {
-	return deriveCloneMultiLineString(mls)
+func (g *MultiLineString) Clone() *MultiLineString {
+	return deriveCloneMultiLineString(g)
 }
 
 // Empty returns true if the collection is empty.
-func (mls *MultiLineString) Empty() bool {
-	return mls.NumLineStrings() == 0
+func (g *MultiLineString) Empty() bool {
+	return g.NumLineStrings() == 0
 }
 
 // Length returns the sum of the length of the LineStrings.
-func (mls *MultiLineString) Length() float64 {
-	return length2(mls.flatCoords, 0, mls.ends, mls.stride)
+func (g *MultiLineString) Length() float64 {
+	return length2(g.flatCoords, 0, g.ends, g.stride)
 }
 
 // LineString returns the ith LineString.
-func (mls *MultiLineString) LineString(i int) *LineString {
+func (g *MultiLineString) LineString(i int) *LineString {
 	offset := 0
 	if i > 0 {
-		offset = mls.ends[i-1]
+		offset = g.ends[i-1]
 	}
-	return NewLineStringFlat(mls.layout, mls.flatCoords[offset:mls.ends[i]])
+	return NewLineStringFlat(g.layout, g.flatCoords[offset:g.ends[i]])
 }
 
 // MustSetCoords sets the coordinates and panics on any error.
-func (mls *MultiLineString) MustSetCoords(coords [][]Coord) *MultiLineString {
-	Must(mls.SetCoords(coords))
-	return mls
+func (g *MultiLineString) MustSetCoords(coords [][]Coord) *MultiLineString {
+	Must(g.SetCoords(coords))
+	return g
 }
 
 // NumLineStrings returns the number of LineStrings.
-func (mls *MultiLineString) NumLineStrings() int {
-	return len(mls.ends)
+func (g *MultiLineString) NumLineStrings() int {
+	return len(g.ends)
 }
 
 // Push appends a LineString.
-func (mls *MultiLineString) Push(ls *LineString) error {
-	if ls.layout != mls.layout {
-		return ErrLayoutMismatch{Got: ls.layout, Want: mls.layout}
+func (g *MultiLineString) Push(ls *LineString) error {
+	if ls.layout != g.layout {
+		return ErrLayoutMismatch{Got: ls.layout, Want: g.layout}
 	}
-	mls.flatCoords = append(mls.flatCoords, ls.flatCoords...)
-	mls.ends = append(mls.ends, len(mls.flatCoords))
+	g.flatCoords = append(g.flatCoords, ls.flatCoords...)
+	g.ends = append(g.ends, len(g.flatCoords))
 	return nil
 }
 
 // SetCoords sets the coordinates.
-func (mls *MultiLineString) SetCoords(coords [][]Coord) (*MultiLineString, error) {
-	if err := mls.setCoords(coords); err != nil {
+func (g *MultiLineString) SetCoords(coords [][]Coord) (*MultiLineString, error) {
+	if err := g.setCoords(coords); err != nil {
 		return nil, err
 	}
-	return mls, nil
+	return g, nil
 }
 
-// SetSRID sets the SRID of mls.
-func (mls *MultiLineString) SetSRID(srid int) *MultiLineString {
-	mls.srid = srid
-	return mls
+// SetSRID sets the SRID of g.
+func (g *MultiLineString) SetSRID(srid int) *MultiLineString {
+	g.srid = srid
+	return g
 }
 
-// Swap swaps the values of mls and mls2.
-func (mls *MultiLineString) Swap(mls2 *MultiLineString) {
-	*mls, *mls2 = *mls2, *mls
+// Swap swaps the values of g and g2.
+func (g *MultiLineString) Swap(g2 *MultiLineString) {
+	*g, *g2 = *g2, *g
 }

--- a/multipoint.go
+++ b/multipoint.go
@@ -12,73 +12,73 @@ func NewMultiPoint(layout Layout) *MultiPoint {
 
 // NewMultiPointFlat returns a new MultiPoint with the given flat coordinates.
 func NewMultiPointFlat(layout Layout, flatCoords []float64) *MultiPoint {
-	mp := new(MultiPoint)
-	mp.layout = layout
-	mp.stride = layout.Stride()
-	mp.flatCoords = flatCoords
-	return mp
+	g := new(MultiPoint)
+	g.layout = layout
+	g.stride = layout.Stride()
+	g.flatCoords = flatCoords
+	return g
 }
 
-// Area returns the area of mp, i.e. zero.
-func (mp *MultiPoint) Area() float64 {
+// Area returns the area of g, i.e. zero.
+func (g *MultiPoint) Area() float64 {
 	return 0
 }
 
 // Clone returns a deep copy.
-func (mp *MultiPoint) Clone() *MultiPoint {
-	return deriveCloneMultiPoint(mp)
+func (g *MultiPoint) Clone() *MultiPoint {
+	return deriveCloneMultiPoint(g)
 }
 
 // Empty returns true if the collection is empty.
-func (mp *MultiPoint) Empty() bool {
-	return mp.NumPoints() == 0
+func (g *MultiPoint) Empty() bool {
+	return g.NumPoints() == 0
 }
 
 // Length returns zero.
-func (mp *MultiPoint) Length() float64 {
+func (g *MultiPoint) Length() float64 {
 	return 0
 }
 
 // MustSetCoords sets the coordinates and panics on any error.
-func (mp *MultiPoint) MustSetCoords(coords []Coord) *MultiPoint {
-	Must(mp.SetCoords(coords))
-	return mp
+func (g *MultiPoint) MustSetCoords(coords []Coord) *MultiPoint {
+	Must(g.SetCoords(coords))
+	return g
 }
 
 // SetCoords sets the coordinates.
-func (mp *MultiPoint) SetCoords(coords []Coord) (*MultiPoint, error) {
-	if err := mp.setCoords(coords); err != nil {
+func (g *MultiPoint) SetCoords(coords []Coord) (*MultiPoint, error) {
+	if err := g.setCoords(coords); err != nil {
 		return nil, err
 	}
-	return mp, nil
+	return g, nil
 }
 
-// SetSRID sets the SRID of mp.
-func (mp *MultiPoint) SetSRID(srid int) *MultiPoint {
-	mp.srid = srid
-	return mp
+// SetSRID sets the SRID of g.
+func (g *MultiPoint) SetSRID(srid int) *MultiPoint {
+	g.srid = srid
+	return g
 }
 
 // NumPoints returns the number of Points.
-func (mp *MultiPoint) NumPoints() int {
-	return mp.NumCoords()
+func (g *MultiPoint) NumPoints() int {
+	return g.NumCoords()
 }
 
 // Point returns the ith Point.
-func (mp *MultiPoint) Point(i int) *Point {
-	return NewPointFlat(mp.layout, mp.Coord(i))
+func (g *MultiPoint) Point(i int) *Point {
+	return NewPointFlat(g.layout, g.Coord(i))
 }
 
 // Push appends a point.
-func (mp *MultiPoint) Push(p *Point) error {
-	if p.layout != mp.layout {
-		return ErrLayoutMismatch{Got: p.layout, Want: mp.layout}
+func (g *MultiPoint) Push(p *Point) error {
+	if p.layout != g.layout {
+		return ErrLayoutMismatch{Got: p.layout, Want: g.layout}
 	}
-	mp.flatCoords = append(mp.flatCoords, p.flatCoords...)
+	g.flatCoords = append(g.flatCoords, p.flatCoords...)
 	return nil
 }
 
-// Swap swaps the values of mp and mp2.
-func (mp *MultiPoint) Swap(mp2 *MultiPoint) {
-	*mp, *mp2 = *mp2, *mp
+// Swap swaps the values of g and g2.
+func (g *MultiPoint) Swap(g2 *MultiPoint) {
+	*g, *g2 = *g2, *g
 }

--- a/multipoint.go
+++ b/multipoint.go
@@ -19,7 +19,7 @@ func NewMultiPointFlat(layout Layout, flatCoords []float64) *MultiPoint {
 	return mp
 }
 
-// Area returns zero.
+// Area returns the area of mp, i.e. zero.
 func (mp *MultiPoint) Area() float64 {
 	return 0
 }

--- a/multipolygon.go
+++ b/multipolygon.go
@@ -12,69 +12,69 @@ func NewMultiPolygon(layout Layout) *MultiPolygon {
 
 // NewMultiPolygonFlat returns a new MultiPolygon with the given flat coordinates.
 func NewMultiPolygonFlat(layout Layout, flatCoords []float64, endss [][]int) *MultiPolygon {
-	mp := new(MultiPolygon)
-	mp.layout = layout
-	mp.stride = layout.Stride()
-	mp.flatCoords = flatCoords
-	mp.endss = endss
-	return mp
+	g := new(MultiPolygon)
+	g.layout = layout
+	g.stride = layout.Stride()
+	g.flatCoords = flatCoords
+	g.endss = endss
+	return g
 }
 
 // Area returns the sum of the area of the individual Polygons.
-func (mp *MultiPolygon) Area() float64 {
-	return doubleArea3(mp.flatCoords, 0, mp.endss, mp.stride) / 2
+func (g *MultiPolygon) Area() float64 {
+	return doubleArea3(g.flatCoords, 0, g.endss, g.stride) / 2
 }
 
 // Clone returns a deep copy.
-func (mp *MultiPolygon) Clone() *MultiPolygon {
-	return deriveCloneMultiPolygon(mp)
+func (g *MultiPolygon) Clone() *MultiPolygon {
+	return deriveCloneMultiPolygon(g)
 }
 
 // Empty returns true if the collection is empty.
-func (mp *MultiPolygon) Empty() bool {
-	return mp.NumPolygons() == 0
+func (g *MultiPolygon) Empty() bool {
+	return g.NumPolygons() == 0
 }
 
 // Length returns the sum of the perimeters of the Polygons.
-func (mp *MultiPolygon) Length() float64 {
-	return length3(mp.flatCoords, 0, mp.endss, mp.stride)
+func (g *MultiPolygon) Length() float64 {
+	return length3(g.flatCoords, 0, g.endss, g.stride)
 }
 
 // MustSetCoords sets the coordinates and panics on any error.
-func (mp *MultiPolygon) MustSetCoords(coords [][][]Coord) *MultiPolygon {
-	Must(mp.SetCoords(coords))
-	return mp
+func (g *MultiPolygon) MustSetCoords(coords [][][]Coord) *MultiPolygon {
+	Must(g.SetCoords(coords))
+	return g
 }
 
 // NumPolygons returns the number of Polygons.
-func (mp *MultiPolygon) NumPolygons() int {
-	return len(mp.endss)
+func (g *MultiPolygon) NumPolygons() int {
+	return len(g.endss)
 }
 
 // Polygon returns the ith Polygon.
-func (mp *MultiPolygon) Polygon(i int) *Polygon {
+func (g *MultiPolygon) Polygon(i int) *Polygon {
 	offset := 0
 	if i > 0 {
-		ends := mp.endss[i-1]
+		ends := g.endss[i-1]
 		offset = ends[len(ends)-1]
 	}
-	ends := make([]int, len(mp.endss[i]))
+	ends := make([]int, len(g.endss[i]))
 	if offset == 0 {
-		copy(ends, mp.endss[i])
+		copy(ends, g.endss[i])
 	} else {
-		for j, end := range mp.endss[i] {
+		for j, end := range g.endss[i] {
 			ends[j] = end - offset
 		}
 	}
-	return NewPolygonFlat(mp.layout, mp.flatCoords[offset:mp.endss[i][len(mp.endss[i])-1]], ends)
+	return NewPolygonFlat(g.layout, g.flatCoords[offset:g.endss[i][len(g.endss[i])-1]], ends)
 }
 
 // Push appends a Polygon.
-func (mp *MultiPolygon) Push(p *Polygon) error {
-	if p.layout != mp.layout {
-		return ErrLayoutMismatch{Got: p.layout, Want: mp.layout}
+func (g *MultiPolygon) Push(p *Polygon) error {
+	if p.layout != g.layout {
+		return ErrLayoutMismatch{Got: p.layout, Want: g.layout}
 	}
-	offset := len(mp.flatCoords)
+	offset := len(g.flatCoords)
 	ends := make([]int, len(p.ends))
 	if offset == 0 {
 		copy(ends, p.ends)
@@ -83,26 +83,26 @@ func (mp *MultiPolygon) Push(p *Polygon) error {
 			ends[i] = end + offset
 		}
 	}
-	mp.flatCoords = append(mp.flatCoords, p.flatCoords...)
-	mp.endss = append(mp.endss, ends)
+	g.flatCoords = append(g.flatCoords, p.flatCoords...)
+	g.endss = append(g.endss, ends)
 	return nil
 }
 
 // SetCoords sets the coordinates.
-func (mp *MultiPolygon) SetCoords(coords [][][]Coord) (*MultiPolygon, error) {
-	if err := mp.setCoords(coords); err != nil {
+func (g *MultiPolygon) SetCoords(coords [][][]Coord) (*MultiPolygon, error) {
+	if err := g.setCoords(coords); err != nil {
 		return nil, err
 	}
-	return mp, nil
+	return g, nil
 }
 
-// SetSRID sets the SRID of mp.
-func (mp *MultiPolygon) SetSRID(srid int) *MultiPolygon {
-	mp.srid = srid
-	return mp
+// SetSRID sets the SRID of g.
+func (g *MultiPolygon) SetSRID(srid int) *MultiPolygon {
+	g.srid = srid
+	return g
 }
 
-// Swap swaps the values of mp and mp2.
-func (mp *MultiPolygon) Swap(mp2 *MultiPolygon) {
-	*mp, *mp2 = *mp2, *mp
+// Swap swaps the values of g and g2.
+func (g *MultiPolygon) Swap(g2 *MultiPolygon) {
+	*g, *g2 = *g2, *g
 }

--- a/point.go
+++ b/point.go
@@ -12,82 +12,82 @@ func NewPoint(l Layout) *Point {
 
 // NewPointFlat allocates a new Point with layout l and flat coordinates flatCoords.
 func NewPointFlat(l Layout, flatCoords []float64) *Point {
-	p := new(Point)
-	p.layout = l
-	p.stride = l.Stride()
-	p.flatCoords = flatCoords
-	return p
+	g := new(Point)
+	g.layout = l
+	g.stride = l.Stride()
+	g.flatCoords = flatCoords
+	return g
 }
 
-// Area returns p's area, i.e. zero.
-func (p *Point) Area() float64 {
+// Area returns g's area, i.e. zero.
+func (g *Point) Area() float64 {
 	return 0
 }
 
-// Clone returns a copy of p that does not alias p.
-func (p *Point) Clone() *Point {
-	return deriveClonePoint(p)
+// Clone returns a copy of g that does not alias g.
+func (g *Point) Clone() *Point {
+	return deriveClonePoint(g)
 }
 
 // Empty returns false.
-func (p *Point) Empty() bool {
+func (g *Point) Empty() bool {
 	return false
 }
 
-// Length returns the length of p, i.e. zero.
-func (p *Point) Length() float64 {
+// Length returns the length of g, i.e. zero.
+func (g *Point) Length() float64 {
 	return 0
 }
 
 // MustSetCoords is like SetCoords but panics on any error.
-func (p *Point) MustSetCoords(coords Coord) *Point {
-	Must(p.SetCoords(coords))
-	return p
+func (g *Point) MustSetCoords(coords Coord) *Point {
+	Must(g.SetCoords(coords))
+	return g
 }
 
-// SetCoords sets the coordinates of p.
-func (p *Point) SetCoords(coords Coord) (*Point, error) {
-	if err := p.setCoords(coords); err != nil {
+// SetCoords sets the coordinates of g.
+func (g *Point) SetCoords(coords Coord) (*Point, error) {
+	if err := g.setCoords(coords); err != nil {
 		return nil, err
 	}
-	return p, nil
+	return g, nil
 }
 
-// SetSRID sets the SRID of p.
-func (p *Point) SetSRID(srid int) *Point {
-	p.srid = srid
-	return p
+// SetSRID sets the SRID of g.
+func (g *Point) SetSRID(srid int) *Point {
+	g.srid = srid
+	return g
 }
 
-// Swap swaps the values of p and p2.
-func (p *Point) Swap(p2 *Point) {
-	*p, *p2 = *p2, *p
+// Swap swaps the values of g and g2.
+func (g *Point) Swap(g2 *Point) {
+	*g, *g2 = *g2, *g
 }
 
-// X returns p's X-coordinate.
-func (p *Point) X() float64 {
-	return p.flatCoords[0]
+// X returns g's X-coordinate.
+func (g *Point) X() float64 {
+	return g.flatCoords[0]
 }
 
-// Y returns p's Y-coordinate.
-func (p *Point) Y() float64 {
-	return p.flatCoords[1]
+// Y returns g's Y-coordinate.
+func (g *Point) Y() float64 {
+	return g.flatCoords[1]
 }
 
-// Z returns p's Z-coordinate, or zero if p has no Z-coordinate.
-func (p *Point) Z() float64 {
-	zIndex := p.layout.ZIndex()
+// Z returns g's Z-coordinate, or zero if g has no Z-coordinate.
+func (g *Point) Z() float64 {
+	zIndex := g.layout.ZIndex()
 	if zIndex == -1 {
 		return 0
 	}
-	return p.flatCoords[zIndex]
+	return g.flatCoords[zIndex]
 }
 
-// M returns p's M-coordinate, or zero if p has no M-coordinate.
-func (p *Point) M() float64 {
-	mIndex := p.layout.MIndex()
+// M returns g's M-coordinate, or zero if g has no M-coordinate.
+func (g *Point) M() float64 {
+	mIndex := g.layout.MIndex()
 	if mIndex == -1 {
 		return 0
 	}
-	return p.flatCoords[mIndex]
+	return g.flatCoords[mIndex]
 }

--- a/polygon.go
+++ b/polygon.go
@@ -14,79 +14,79 @@ func NewPolygon(layout Layout) *Polygon {
 
 // NewPolygonFlat returns a new Polygon with the given flat coordinates.
 func NewPolygonFlat(layout Layout, flatCoords []float64, ends []int) *Polygon {
-	p := new(Polygon)
-	p.layout = layout
-	p.stride = layout.Stride()
-	p.flatCoords = flatCoords
-	p.ends = ends
-	return p
+	g := new(Polygon)
+	g.layout = layout
+	g.stride = layout.Stride()
+	g.flatCoords = flatCoords
+	g.ends = ends
+	return g
 }
 
 // Area returns the area.
-func (p *Polygon) Area() float64 {
-	return doubleArea2(p.flatCoords, 0, p.ends, p.stride) / 2
+func (g *Polygon) Area() float64 {
+	return doubleArea2(g.flatCoords, 0, g.ends, g.stride) / 2
 }
 
 // Clone returns a deep copy.
-func (p *Polygon) Clone() *Polygon {
-	return deriveClonePolygon(p)
+func (g *Polygon) Clone() *Polygon {
+	return deriveClonePolygon(g)
 }
 
 // Empty returns false.
-func (p *Polygon) Empty() bool {
+func (g *Polygon) Empty() bool {
 	return false
 }
 
 // Length returns the perimter.
-func (p *Polygon) Length() float64 {
-	return length2(p.flatCoords, 0, p.ends, p.stride)
+func (g *Polygon) Length() float64 {
+	return length2(g.flatCoords, 0, g.ends, g.stride)
 }
 
 // LinearRing returns the ith LinearRing.
-func (p *Polygon) LinearRing(i int) *LinearRing {
+func (g *Polygon) LinearRing(i int) *LinearRing {
 	offset := 0
 	if i > 0 {
-		offset = p.ends[i-1]
+		offset = g.ends[i-1]
 	}
-	return NewLinearRingFlat(p.layout, p.flatCoords[offset:p.ends[i]])
+	return NewLinearRingFlat(g.layout, g.flatCoords[offset:g.ends[i]])
 }
 
 // MustSetCoords sets the coordinates and panics on any error.
-func (p *Polygon) MustSetCoords(coords [][]Coord) *Polygon {
-	Must(p.SetCoords(coords))
-	return p
+func (g *Polygon) MustSetCoords(coords [][]Coord) *Polygon {
+	Must(g.SetCoords(coords))
+	return g
 }
 
 // NumLinearRings returns the number of LinearRings.
-func (p *Polygon) NumLinearRings() int {
-	return len(p.ends)
+func (g *Polygon) NumLinearRings() int {
+	return len(g.ends)
 }
 
 // Push appends a LinearRing.
-func (p *Polygon) Push(lr *LinearRing) error {
-	if lr.layout != p.layout {
-		return ErrLayoutMismatch{Got: lr.layout, Want: p.layout}
+func (g *Polygon) Push(lr *LinearRing) error {
+	if lr.layout != g.layout {
+		return ErrLayoutMismatch{Got: lr.layout, Want: g.layout}
 	}
-	p.flatCoords = append(p.flatCoords, lr.flatCoords...)
-	p.ends = append(p.ends, len(p.flatCoords))
+	g.flatCoords = append(g.flatCoords, lr.flatCoords...)
+	g.ends = append(g.ends, len(g.flatCoords))
 	return nil
 }
 
 // SetCoords sets the coordinates.
-func (p *Polygon) SetCoords(coords [][]Coord) (*Polygon, error) {
-	if err := p.setCoords(coords); err != nil {
+func (g *Polygon) SetCoords(coords [][]Coord) (*Polygon, error) {
+	if err := g.setCoords(coords); err != nil {
 		return nil, err
 	}
-	return p, nil
+	return g, nil
 }
 
-// SetSRID sets the SRID of p.
-func (p *Polygon) SetSRID(srid int) *Polygon {
-	p.srid = srid
-	return p
+// SetSRID sets the SRID of g.
+func (g *Polygon) SetSRID(srid int) *Polygon {
+	g.srid = srid
+	return g
 }
 
-// Swap swaps the values of p and p2.
-func (p *Polygon) Swap(p2 *Polygon) {
-	*p, *p2 = *p2, *p
+// Swap swaps the values of g and g2.
+func (g *Polygon) Swap(g2 *Polygon) {
+	*g, *g2 = *g2, *g
 }


### PR DESCRIPTION
 - Document more exported functions
 - Use `g` as the receiver name everywhere.
 - Fix a copy-and-paste error in `LinearRing.Area`
