### PR TITLE
Export WKB encodings

### DIFF
--- a/encoding/ewkbhex/ewkbhex.go
+++ b/encoding/ewkbhex/ewkbhex.go
@@ -10,6 +10,13 @@ import (
 	"github.com/twpayne/go-geom/encoding/ewkb"
 )
 
+var (
+	// XDR is big endian.
+	XDR = ewkb.XDR
+	// NDR is little endian.
+	NDR = ewkb.NDR
+)
+
 // Encode encodes an arbitrary geometry to a string.
 func Encode(g geom.T, byteOrder binary.ByteOrder) (string, error) {
 	ewkb, err := ewkb.Marshal(g, byteOrder)

--- a/encoding/wkbhex/wkbhex.go
+++ b/encoding/wkbhex/wkbhex.go
@@ -10,6 +10,13 @@ import (
 	"github.com/twpayne/go-geom/encoding/wkb"
 )
 
+var (
+	// XDR is big endian.
+	XDR = wkb.XDR
+	// NDR is little endian.
+	NDR = wkb.NDR
+)
+
 // Encode encodes an arbitrary geometry to a string.
 func Encode(g geom.T, byteOrder binary.ByteOrder) (string, error) {
 	wkb, err := wkb.Marshal(g, byteOrder)


### PR DESCRIPTION
This reduces the number of imports needed by users when using hex formats.