### PR TITLE
geojson: never omit properties or type

### DIFF
--- a/encoding/geojson/geojson.go
+++ b/encoding/geojson/geojson.go
@@ -41,10 +41,10 @@ type Feature struct {
 }
 
 type geojsonFeature struct {
-	Type       string                 `json:"type,omitempty"`
+	Type       string                 `json:"type"`
 	ID         string                 `json:"id,omitempty"`
-	Geometry   *Geometry              `json:"geometry,omitempty"`
-	Properties map[string]interface{} `json:"properties,omitempty"`
+	Geometry   *Geometry              `json:"geometry"`
+	Properties map[string]interface{} `json:"properties"`
 }
 
 // A FeatureCollection is a GeoJSON FeatureCollection.
@@ -53,8 +53,8 @@ type FeatureCollection struct {
 }
 
 type geojsonFeatureCollection struct {
-	Type     string     `json:"type,omitempty"`
-	Features []*Feature `json:"features,omitempty"`
+	Type     string     `json:"type"`
+	Features []*Feature `json:"features"`
 }
 
 func guessLayout0(coords0 []float64) (geom.Layout, error) {
@@ -377,10 +377,14 @@ func (f *Feature) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements json.Marshaler.MarshalJSON.
 func (fc *FeatureCollection) MarshalJSON() ([]byte, error) {
-	return json.Marshal(&geojsonFeatureCollection{
+	gfc := &geojsonFeatureCollection{
 		Type:     "FeatureCollection",
 		Features: fc.Features,
-	})
+	}
+	if gfc.Features == nil {
+		gfc.Features = []*Feature{}
+	}
+	return json.Marshal(gfc)
 }
 
 // UnmarshalJSON implements json.Unmarshaler.UnmarshalJSON

--- a/encoding/geojson/geojson_test.go
+++ b/encoding/geojson/geojson_test.go
@@ -193,14 +193,14 @@ func TestFeature(t *testing.T) {
 				ID:       "0",
 				Geometry: geom.NewPoint(geom.XY).MustSetCoords(geom.Coord{1, 2}),
 			},
-			s: `{"type":"Feature","id":"0","geometry":{"type":"Point","coordinates":[1,2]}}`,
+			s: `{"type":"Feature","id":"0","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}`,
 		},
 		{
 			f: &Feature{
 				ID:       "f",
 				Geometry: geom.NewPoint(geom.XY).MustSetCoords(geom.Coord{1, 2}),
 			},
-			s: `{"type":"Feature","id":"f","geometry":{"type":"Point","coordinates":[1,2]}}`,
+			s: `{"type":"Feature","id":"f","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}`,
 		},
 	} {
 		if got, err := json.Marshal(tc.f); err != nil || string(got) != tc.s {


### PR DESCRIPTION
I tried to paste some marshalled features into http://geojson.io and it gave me a bunch of errors

According to the spec:

* `feature.properties`  must be present, but can be `null`.
* `feature.geometry` must always be present.
* `feature.type` must always be present.
* `feature_collection.features` must be an array, but can be empty.