### PR TITLE
move to actual module for sqlmock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
         - go get github.com/d4l3k/messagediff
         - go get github.com/lib/pq
         - go get github.com/twpayne/go-kml
-        - go get gopkg.in/DATA-DOG/go-sqlmock.v1
+        - go get github.com/DATA-DOG/go-sqlmock
 
 script: ./scripts/run-tests.sh
 

--- a/encoding/ewkb/sql_example_test.go
+++ b/encoding/ewkb/sql_example_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	"gopkg.in/DATA-DOG/go-sqlmock.v1"
+	"github.com/DATA-DOG/go-sqlmock"
 
 	"github.com/twpayne/go-geom"
 	"github.com/twpayne/go-geom/encoding/ewkb"

--- a/encoding/wkb/sql_test.go
+++ b/encoding/wkb/sql_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	"gopkg.in/DATA-DOG/go-sqlmock.v1"
+	"github.com/DATA-DOG/go-sqlmock"
 
 	"github.com/twpayne/go-geom"
 	"github.com/twpayne/go-geom/encoding/wkb"

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/twpayne/go-geom
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.3.2
 	github.com/d4l3k/messagediff v1.2.1
 	github.com/lib/pq v1.0.0
 	github.com/twpayne/go-kml v1.0.0
-	gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/DATA-DOG/go-sqlmock v1.3.0 h1:FVCohIoYO7IJoDDVpV2pdq7SgrMH6wHnuTyrdrxJNoY=
-github.com/DATA-DOG/go-sqlmock v1.3.0/go.mod h1:OdE7CF6DbADk7lN8LIKRzRJTTZXIjtWgA5THM5lhBAw=
 github.com/DATA-DOG/go-sqlmock v1.3.2 h1:2L2f5t3kKnCLxnClDD/PrDfExFFa1wjESgxHG/B1ibo=
 github.com/DATA-DOG/go-sqlmock v1.3.2/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/d4l3k/messagediff v1.2.1 h1:ZcAIMYsUg0EAp9X+tt8/enBE/Q8Yd5kzPynLyKptt9U=

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,7 @@
+github.com/DATA-DOG/go-sqlmock v1.3.0 h1:FVCohIoYO7IJoDDVpV2pdq7SgrMH6wHnuTyrdrxJNoY=
+github.com/DATA-DOG/go-sqlmock v1.3.0/go.mod h1:OdE7CF6DbADk7lN8LIKRzRJTTZXIjtWgA5THM5lhBAw=
+github.com/DATA-DOG/go-sqlmock v1.3.2 h1:2L2f5t3kKnCLxnClDD/PrDfExFFa1wjESgxHG/B1ibo=
+github.com/DATA-DOG/go-sqlmock v1.3.2/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/d4l3k/messagediff v1.2.1 h1:ZcAIMYsUg0EAp9X+tt8/enBE/Q8Yd5kzPynLyKptt9U=
 github.com/d4l3k/messagediff v1.2.1/go.mod h1:Oozbb1TVXFac9FtSIxHBMnBCq2qeH/2KkEQxENCrlLo=
 github.com/lib/pq v1.0.0 h1:X5PMW56eZitiTeO7tKzZxFCSpbFZJtkMMooicw2us9A=
@@ -5,5 +9,3 @@ github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/twpayne/go-kml v1.0.0 h1:XMyRRufIWOYaPGW1UzTnqJO42oY7wngXyO7kW/vzXjI=
 github.com/twpayne/go-kml v1.0.0/go.mod h1:LlvLIQSfMqYk2O7Nx8vYAbSLv4K9rjMvLlEdUKWdjq0=
 github.com/twpayne/go-polyline v1.0.0/go.mod h1:ICh24bcLYBX8CknfvNPKqoTbe+eg+MX1NPyJmSBo7pU=
-gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0 h1:FVCohIoYO7IJoDDVpV2pdq7SgrMH6wHnuTyrdrxJNoY=
-gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0/go.mod h1:OdE7CF6DbADk7lN8LIKRzRJTTZXIjtWgA5THM5lhBAw=


### PR DESCRIPTION
The module name for datadog is `github.com/DATA-DOG/go-sqlmock`

https://github.com/DATA-DOG/go-sqlmock/commit/472e287dbafe67e526a3797165b64cb14f34705a

When I tried to add this library to a go modules project, it was failing with a message about invalid import paths.

```shellsession
$ go get -u github.com/twpayne/go-geom
go: finding github.com/twpayne/go-geom v1.0.4
go: gopkg.in/DATA-DOG/go-sqlmock.v1@v1.3.2: go.mod has non-....v1 module path "github.com/DATA-DOG/go-sqlmock" at revision v1.3.2
go get: error loading module requirements
```

So I figured with go.mod we already specify a minimum version, so it can just not use gopkg.in

Signed-off-by: Ivan Porto Carrero <ivan@oneconcern.com>