### PR TITLE
Use github.com/stretchr/testify

### DIFF
--- a/bounds_test.go
+++ b/bounds_test.go
@@ -1,234 +1,207 @@
 package geom
 
 import (
-	"reflect"
+	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBoundsExtend(t *testing.T) {
-	for _, tc := range []struct {
-		b    *Bounds
-		g    T
-		want *Bounds
+	for i, tc := range []struct {
+		b        *Bounds
+		g        T
+		expected *Bounds
 	}{
 		{
-			b:    NewBounds(XY).SetCoords(Coord{0, 0}, Coord{0, 0}),
-			g:    NewPoint(XY).MustSetCoords(Coord{10, -10}),
-			want: NewBounds(XY).SetCoords(Coord{0, -10}, Coord{10, 0}),
+			b:        NewBounds(XY).SetCoords(Coord{0, 0}, Coord{0, 0}),
+			g:        NewPoint(XY).MustSetCoords(Coord{10, -10}),
+			expected: NewBounds(XY).SetCoords(Coord{0, -10}, Coord{10, 0}),
 		},
 		{
-			b:    NewBounds(XY).SetCoords(Coord{-100, -100}, Coord{100, 100}),
-			g:    NewPoint(XY).MustSetCoords(Coord{-10, 10}),
-			want: NewBounds(XY).SetCoords(Coord{-100, -100}, Coord{100, 100}),
+			b:        NewBounds(XY).SetCoords(Coord{-100, -100}, Coord{100, 100}),
+			g:        NewPoint(XY).MustSetCoords(Coord{-10, 10}),
+			expected: NewBounds(XY).SetCoords(Coord{-100, -100}, Coord{100, 100}),
 		},
 		{
-			b:    NewBounds(XYZ).SetCoords(Coord{0, 0, -1}, Coord{10, 10, 1}),
-			g:    NewPoint(XY).MustSetCoords(Coord{5, -10}),
-			want: NewBounds(XYZ).SetCoords(Coord{0, -10, -1}, Coord{10, 10, 1}),
+			b:        NewBounds(XYZ).SetCoords(Coord{0, 0, -1}, Coord{10, 10, 1}),
+			g:        NewPoint(XY).MustSetCoords(Coord{5, -10}),
+			expected: NewBounds(XYZ).SetCoords(Coord{0, -10, -1}, Coord{10, 10, 1}),
 		},
 		{
-			b:    NewBounds(XYZ).SetCoords(Coord{0, 0, 0}, Coord{10, 10, 10}),
-			g:    NewPoint(XYZ).MustSetCoords(Coord{5, -10, 3}),
-			want: NewBounds(XYZ).SetCoords(Coord{0, -10, 0}, Coord{10, 10, 10}),
+			b:        NewBounds(XYZ).SetCoords(Coord{0, 0, 0}, Coord{10, 10, 10}),
+			g:        NewPoint(XYZ).MustSetCoords(Coord{5, -10, 3}),
+			expected: NewBounds(XYZ).SetCoords(Coord{0, -10, 0}, Coord{10, 10, 10}),
 		},
 		{
-			b:    NewBounds(XYZ).SetCoords(Coord{0, 0, 0}, Coord{10, 10, 10}),
-			g:    NewMultiPoint(XYM).MustSetCoords([]Coord{{-1, -1, -1}, {11, 11, 11}}),
-			want: NewBounds(XYZM).SetCoords(Coord{-1, -1, 0, -1}, Coord{11, 11, 10, 11}),
+			b:        NewBounds(XYZ).SetCoords(Coord{0, 0, 0}, Coord{10, 10, 10}),
+			g:        NewMultiPoint(XYM).MustSetCoords([]Coord{{-1, -1, -1}, {11, 11, 11}}),
+			expected: NewBounds(XYZM).SetCoords(Coord{-1, -1, 0, -1}, Coord{11, 11, 10, 11}),
 		},
 		{
-			b:    NewBounds(XY).SetCoords(Coord{0, 0}, Coord{10, 10}),
-			g:    NewMultiPoint(XYM).MustSetCoords([]Coord{{-1, -1, -1}, {11, 11, 11}}),
-			want: NewBounds(XYM).SetCoords(Coord{-1, -1, -1}, Coord{11, 11, 11}),
+			b:        NewBounds(XY).SetCoords(Coord{0, 0}, Coord{10, 10}),
+			g:        NewMultiPoint(XYM).MustSetCoords([]Coord{{-1, -1, -1}, {11, 11, 11}}),
+			expected: NewBounds(XYM).SetCoords(Coord{-1, -1, -1}, Coord{11, 11, 11}),
 		},
 		{
-			b:    NewBounds(XY).SetCoords(Coord{0, 0}, Coord{10, 10}),
-			g:    NewMultiPoint(XYZ).MustSetCoords([]Coord{{-1, -1, -1}, {11, 11, 11}}),
-			want: NewBounds(XYZ).SetCoords(Coord{-1, -1, -1}, Coord{11, 11, 11}),
+			b:        NewBounds(XY).SetCoords(Coord{0, 0}, Coord{10, 10}),
+			g:        NewMultiPoint(XYZ).MustSetCoords([]Coord{{-1, -1, -1}, {11, 11, 11}}),
+			expected: NewBounds(XYZ).SetCoords(Coord{-1, -1, -1}, Coord{11, 11, 11}),
 		},
 		{
-			b:    NewBounds(XYM).SetCoords(Coord{0, 0, 0}, Coord{10, 10, 10}),
-			g:    NewMultiPoint(XYZ).MustSetCoords([]Coord{{-1, -1, -1}, {11, 11, 11}}),
-			want: NewBounds(XYZM).SetCoords(Coord{-1, -1, -1, 0}, Coord{11, 11, 11, 10}),
+			b:        NewBounds(XYM).SetCoords(Coord{0, 0, 0}, Coord{10, 10, 10}),
+			g:        NewMultiPoint(XYZ).MustSetCoords([]Coord{{-1, -1, -1}, {11, 11, 11}}),
+			expected: NewBounds(XYZM).SetCoords(Coord{-1, -1, -1, 0}, Coord{11, 11, 11, 10}),
 		},
 	} {
-		if got := tc.b.Clone().Extend(tc.g); !reflect.DeepEqual(got, tc.want) {
-			t.Errorf("%+v.Extend(%+v) == %+v, want %+v", tc.b, tc.g, got, tc.want)
-		}
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.b.Clone().Extend(tc.g))
+		})
 	}
 }
 
 func TestBoundsIsEmpty(t *testing.T) {
-	for i, testData := range []struct {
-		bounds  Bounds
-		isEmpty bool
+	for i, tc := range []struct {
+		b        *Bounds
+		expected bool
 	}{
 		{
-			bounds:  Bounds{layout: XY, min: Coord{0, 0}, max: Coord{-1, -1}},
-			isEmpty: true,
+			b:        &Bounds{layout: XY, min: Coord{0, 0}, max: Coord{-1, -1}},
+			expected: true,
 		},
 		{
-			bounds:  Bounds{layout: XY, min: Coord{0, 0}, max: Coord{0, 0}},
-			isEmpty: false,
+			b:        &Bounds{layout: XY, min: Coord{0, 0}, max: Coord{0, 0}},
+			expected: false,
 		},
 		{
-			bounds:  Bounds{layout: XY, min: Coord{-100, -100}, max: Coord{100, 100}},
-			isEmpty: false,
+			b:        &Bounds{layout: XY, min: Coord{-100, -100}, max: Coord{100, 100}},
+			expected: false,
 		},
 	} {
-		copy := Bounds{layout: testData.bounds.layout, min: testData.bounds.min, max: testData.bounds.max}
-		for j := 0; j < 10; j++ {
-			// do multiple checks to verify no obvious side effects are caused
-			isEmpty := copy.IsEmpty()
-			if isEmpty != testData.isEmpty {
-				t.Errorf("Test %v Failed.  Expected: %v but got: %v", i+1, testData.isEmpty, isEmpty)
-				break
-			}
-			if !reflect.DeepEqual(copy, testData.bounds) {
-				t.Errorf("Test %v Failed.  Function IsEmpty modified internal state of bounds.  Before: \n%v After: \n%v", i+1, testData.bounds, copy)
-				break
-			}
-		}
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.b.IsEmpty())
+		})
 	}
 }
 
 func TestBoundsOverlaps(t *testing.T) {
-	for i, testData := range []struct {
-		bounds, other Bounds
-		overlaps      bool
+	for i, tc := range []struct {
+		b1       *Bounds
+		b2       *Bounds
+		expected bool
 	}{
 		{
-			bounds:   Bounds{layout: XY, min: Coord{0, 0}, max: Coord{0, 0}},
-			other:    Bounds{layout: XY, min: Coord{-10, 0}, max: Coord{-5, 10}},
-			overlaps: false,
+			b1:       &Bounds{layout: XY, min: Coord{0, 0}, max: Coord{0, 0}},
+			b2:       &Bounds{layout: XY, min: Coord{-10, 0}, max: Coord{-5, 10}},
+			expected: false,
 		},
 		{
-			bounds:   Bounds{layout: XY, min: Coord{-100, -100}, max: Coord{100, 100}},
-			other:    Bounds{layout: XY, min: Coord{-10, 0}, max: Coord{-5, 10}},
-			overlaps: true,
+			b1:       &Bounds{layout: XY, min: Coord{-100, -100}, max: Coord{100, 100}},
+			b2:       &Bounds{layout: XY, min: Coord{-10, 0}, max: Coord{-5, 10}},
+			expected: true,
 		},
 		{
-			bounds:   Bounds{layout: XY, min: Coord{1, 1}, max: Coord{5, 5}},
-			other:    Bounds{layout: XY, min: Coord{-5, -5}, max: Coord{-1, -1}},
-			overlaps: false,
+			b1:       &Bounds{layout: XY, min: Coord{1, 1}, max: Coord{5, 5}},
+			b2:       &Bounds{layout: XY, min: Coord{-5, -5}, max: Coord{-1, -1}},
+			expected: false,
 		},
 		{
-			bounds:   Bounds{layout: XYZ, min: Coord{-100, -100, -100}, max: Coord{100, 100, 100}},
-			other:    Bounds{layout: XYZ, min: Coord{-10, 0, 0}, max: Coord{-5, 10, 10}},
-			overlaps: true,
+			b1:       &Bounds{layout: XYZ, min: Coord{-100, -100, -100}, max: Coord{100, 100, 100}},
+			b2:       &Bounds{layout: XYZ, min: Coord{-10, 0, 0}, max: Coord{-5, 10, 10}},
+			expected: true,
 		},
 		{
-			bounds:   Bounds{layout: XYZ, min: Coord{0, 0, 0}, max: Coord{100, 100, 100}},
-			other:    Bounds{layout: XYZ, min: Coord{5, 5, -10}, max: Coord{10, 10, -5}},
-			overlaps: false,
+			b1:       &Bounds{layout: XYZ, min: Coord{0, 0, 0}, max: Coord{100, 100, 100}},
+			b2:       &Bounds{layout: XYZ, min: Coord{5, 5, -10}, max: Coord{10, 10, -5}},
+			expected: false,
 		},
 		{
-			bounds:   Bounds{layout: XY, min: Coord{0, 0}, max: Coord{0, 0}},
-			other:    Bounds{layout: XY, min: Coord{-10, -10}, max: Coord{-0.000000000000000000000000000001, 0}},
-			overlaps: false,
+			b1:       &Bounds{layout: XY, min: Coord{0, 0}, max: Coord{0, 0}},
+			b2:       &Bounds{layout: XY, min: Coord{-10, -10}, max: Coord{-0.000000000000000000000000000001, 0}},
+			expected: false,
 		},
 	} {
-		copy := Bounds{layout: testData.bounds.layout, min: testData.bounds.min, max: testData.bounds.max}
-		for j := 0; j < 10; j++ {
-			// do multiple checks to verify no obvious side effects are caused
-			overlaps := copy.Overlaps(testData.bounds.layout, &testData.other)
-			if overlaps != testData.overlaps {
-				t.Errorf("Test %v Failed.  Expected: %v but got: %v", i+1, testData.overlaps, overlaps)
-				break
-			}
-			if !reflect.DeepEqual(copy, testData.bounds) {
-				t.Errorf("Test %v Failed.  Function Overlaps modified internal state of bounds.  Before: \n%v After: \n%v", i+1, testData.bounds, copy)
-				break
-			}
-		}
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.b1.Overlaps(tc.b1.layout, tc.b2))
+		})
 	}
 }
 
 func TestBoundsOverlapsPoint(t *testing.T) {
-	for i, testData := range []struct {
-		bounds   Bounds
-		point    Coord
-		overlaps bool
+	for i, tc := range []struct {
+		b        *Bounds
+		p        Coord
+		expected bool
 	}{
 		{
-			bounds:   Bounds{layout: XY, min: Coord{0, 0}, max: Coord{0, 0}},
-			point:    Coord{-10, 0},
-			overlaps: false,
+			b:        &Bounds{layout: XY, min: Coord{0, 0}, max: Coord{0, 0}},
+			p:        Coord{-10, 0},
+			expected: false,
 		},
 		{
-			bounds:   Bounds{layout: XY, min: Coord{-100, -100}, max: Coord{100, 100}},
-			point:    Coord{-10, 0},
-			overlaps: true,
+			b:        &Bounds{layout: XY, min: Coord{-100, -100}, max: Coord{100, 100}},
+			p:        Coord{-10, 0},
+			expected: true,
 		},
 		{
-			bounds:   Bounds{layout: XYZ, min: Coord{-100, -100, -100}, max: Coord{100, 100, 100}},
-			point:    Coord{-5, 10, 10},
-			overlaps: true,
+			b:        &Bounds{layout: XYZ, min: Coord{-100, -100, -100}, max: Coord{100, 100, 100}},
+			p:        Coord{-5, 10, 10},
+			expected: true,
 		},
 		{
-			bounds:   Bounds{layout: XYZ, min: Coord{0, 0, 0}, max: Coord{100, 100, 100}},
-			point:    Coord{5, 5, -10},
-			overlaps: false,
+			b:        &Bounds{layout: XYZ, min: Coord{0, 0, 0}, max: Coord{100, 100, 100}},
+			p:        Coord{5, 5, -10},
+			expected: false,
 		},
 		{
-			bounds:   Bounds{layout: XY, min: Coord{0, 0}, max: Coord{10, 10}},
-			point:    Coord{-0.000000000000000000000000000001, 0},
-			overlaps: false,
+			b:        &Bounds{layout: XY, min: Coord{0, 0}, max: Coord{10, 10}},
+			p:        Coord{-0.000000000000000000000000000001, 0},
+			expected: false,
 		},
 	} {
-		copy := Bounds{layout: testData.bounds.layout, min: testData.bounds.min, max: testData.bounds.max}
-		for j := 0; j < 10; j++ {
-			// do multiple checks to verify no obvious side effects are caused
-			overlaps := copy.OverlapsPoint(testData.bounds.layout, testData.point)
-			if overlaps != testData.overlaps {
-				t.Errorf("Test %v Failed.  Expected: %v but got: %v", i+1, testData.overlaps, overlaps)
-				break
-			}
-			if !reflect.DeepEqual(copy, testData.bounds) {
-				t.Errorf("Test %v Failed.  Function Overlaps modified internal state of bounds.  Before: \n%v After: \n%v", i+1, testData.bounds, copy)
-				break
-			}
-		}
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.b.OverlapsPoint(tc.b.layout, tc.p))
+		})
 	}
 }
 
 func TestBoundsPolygon(t *testing.T) {
-	for _, tc := range []struct {
-		b    *Bounds
-		want *Polygon
+	for i, tc := range []struct {
+		b        *Bounds
+		expected *Polygon
 	}{
 		{
-			b:    NewBounds(NoLayout),
-			want: NewPolygon(XY),
+			b:        NewBounds(NoLayout),
+			expected: NewPolygon(XY),
 		},
 		{
-			b:    NewBounds(XY).Set(0, 0, 1, 1),
-			want: NewPolygon(XY).MustSetCoords([][]Coord{{{0, 0}, {0, 1}, {1, 1}, {1, 0}, {0, 0}}}),
+			b:        NewBounds(XY).Set(0, 0, 1, 1),
+			expected: NewPolygon(XY).MustSetCoords([][]Coord{{{0, 0}, {0, 1}, {1, 1}, {1, 0}, {0, 0}}}),
 		},
 		{
-			b:    NewBounds(XYZ).Set(0, 0, 0, 1, 1, 1),
-			want: NewPolygon(XY).MustSetCoords([][]Coord{{{0, 0}, {0, 1}, {1, 1}, {1, 0}, {0, 0}}}),
+			b:        NewBounds(XYZ).Set(0, 0, 0, 1, 1, 1),
+			expected: NewPolygon(XY).MustSetCoords([][]Coord{{{0, 0}, {0, 1}, {1, 1}, {1, 0}, {0, 0}}}),
 		},
 		{
-			b:    NewBounds(XYM).Set(0, 0, 0, 1, 1, 1),
-			want: NewPolygon(XY).MustSetCoords([][]Coord{{{0, 0}, {0, 1}, {1, 1}, {1, 0}, {0, 0}}}),
+			b:        NewBounds(XYM).Set(0, 0, 0, 1, 1, 1),
+			expected: NewPolygon(XY).MustSetCoords([][]Coord{{{0, 0}, {0, 1}, {1, 1}, {1, 0}, {0, 0}}}),
 		},
 		{
-			b:    NewBounds(XYZM).Set(0, 0, 0, 0, 1, 1, 1, 1),
-			want: NewPolygon(XY).MustSetCoords([][]Coord{{{0, 0}, {0, 1}, {1, 1}, {1, 0}, {0, 0}}}),
+			b:        NewBounds(XYZM).Set(0, 0, 0, 0, 1, 1, 1, 1),
+			expected: NewPolygon(XY).MustSetCoords([][]Coord{{{0, 0}, {0, 1}, {1, 1}, {1, 0}, {0, 0}}}),
 		},
 		{
-			b:    NewBounds(XY).Set(1, 2, 3, 4),
-			want: NewPolygon(XY).MustSetCoords([][]Coord{{{1, 2}, {1, 4}, {3, 4}, {3, 2}, {1, 2}}}),
+			b:        NewBounds(XY).Set(1, 2, 3, 4),
+			expected: NewPolygon(XY).MustSetCoords([][]Coord{{{1, 2}, {1, 4}, {3, 4}, {3, 2}, {1, 2}}}),
 		},
 		{
-			b:    NewBounds(XYZ).Set(1, 2, 3, 4, 5, 6),
-			want: NewPolygon(XY).MustSetCoords([][]Coord{{{1, 2}, {1, 5}, {4, 5}, {4, 2}, {1, 2}}}),
+			b:        NewBounds(XYZ).Set(1, 2, 3, 4, 5, 6),
+			expected: NewPolygon(XY).MustSetCoords([][]Coord{{{1, 2}, {1, 5}, {4, 5}, {4, 2}, {1, 2}}}),
 		},
 	} {
-		if got := tc.b.Polygon(); !reflect.DeepEqual(tc.want, got) {
-			t.Errorf("%v.Polygon() == %v, want %v", tc.b, got, tc.want)
-		}
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.b.Polygon())
+		})
 	}
 }
 
@@ -236,38 +209,23 @@ func TestBoundsSet(t *testing.T) {
 	bounds := Bounds{layout: XY, min: Coord{0, 0}, max: Coord{10, 10}}
 	bounds.Set(0, 0, 20, 20)
 	expected := Bounds{layout: XY, min: Coord{0, 0}, max: Coord{20, 20}}
-	if !reflect.DeepEqual(expected, bounds) {
-		t.Errorf("Expected %v but got %v", expected, bounds)
-	}
-	func() {
-		defer func() {
-			if r := recover(); r == nil {
-				t.Error("Expected a panic but didn't get it as expected")
-			} else if !reflect.DeepEqual(expected, bounds) {
-				t.Errorf("Set modified bounds even though error was thrown. Before %v after %v", expected, bounds)
-			}
-		}()
+	assert.Equal(t, expected, bounds)
+	assert.Panics(t, func() {
 		bounds.Set(2, 2, 2, 2, 2)
-	}()
+	})
 }
 
 func TestBoundsSetCoords(t *testing.T) {
 	bounds := &Bounds{layout: XY, min: Coord{0, 0}, max: Coord{10, 10}}
 	bounds.SetCoords(Coord{0, 0}, Coord{20, 20})
 	expected := Bounds{layout: XY, min: Coord{0, 0}, max: Coord{20, 20}}
-	if !reflect.DeepEqual(expected, *bounds) {
-		t.Errorf("Expected %v but got %v", expected, *bounds)
-	}
+	assert.Equal(t, expected, *bounds)
 
 	bounds = NewBounds(XY)
 	bounds.SetCoords(Coord{0, 0}, Coord{20, 20})
-	if !reflect.DeepEqual(expected, *bounds) {
-		t.Errorf("Expected %v but got %v", expected, *bounds)
-	}
+	assert.Equal(t, expected, *bounds)
 
 	bounds = NewBounds(XY)
 	bounds.SetCoords(Coord{20, 0}, Coord{0, 20}) // set coords should ensure valid min / max
-	if !reflect.DeepEqual(expected, *bounds) {
-		t.Errorf("Expected %v but got %v", expected, *bounds)
-	}
+	assert.Equal(t, expected, *bounds)
 }

--- a/geom_test.go
+++ b/geom_test.go
@@ -1,8 +1,9 @@
 package geom
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -167,9 +168,7 @@ func TestArea(t *testing.T) {
 			want: 57,
 		},
 	} {
-		if got := tc.g.Area(); got != tc.want {
-			t.Errorf("%#v.Area() == %f, want %f", tc.g, got, tc.want)
-		}
+		assert.Equal(t, tc.want, tc.g.Area())
 	}
 }
 
@@ -182,9 +181,8 @@ func TestSet(t *testing.T) {
 		{Coord{1.0, 2.0}, Coord{2.0, 3.0, 4.0}, Coord{2.0, 3.0}},
 		{Coord{1.0, 2.0, 3.0}, Coord{2.0, 3.0}, Coord{2.0, 3.0, 3.0}},
 	} {
-		if tc.c.Set(tc.other); !reflect.DeepEqual(tc.c, tc.want) {
-			t.Errorf("%v.Set(%v); got %v, want %v", tc.c, tc.other, tc.c, tc.want)
-		}
+		tc.c.Set(tc.other)
+		assert.Equal(t, tc.want, tc.c)
 	}
 }
 
@@ -200,9 +198,7 @@ func TestLayoutString(t *testing.T) {
 		{XYZM, "XYZM"},
 		{Layout(5), "Layout(5)"},
 	} {
-		if got := tc.l.String(); got != tc.want {
-			t.Errorf("%#v.String() == %v, want %v", tc.l, got, tc.want)
-		}
+		assert.Equal(t, tc.want, tc.l.String())
 	}
 }
 
@@ -318,9 +314,7 @@ func TestVerify(t *testing.T) {
 			errIncorrectEnd,
 		},
 	} {
-		if got := tc.v.verify(); got != tc.want {
-			t.Errorf("%#v.verify() == %v, want %v", tc.v, got, tc.want)
-		}
+		assert.Equal(t, tc.want, tc.v.verify())
 	}
 }
 
@@ -421,9 +415,7 @@ func TestEqualCoords(t *testing.T) {
 			equal:  false,
 		},
 	} {
-		if tc.c1.Equal(tc.layout, tc.c2) != tc.equal {
-			t.Errorf("%v.Equals(%s, %v) is not '%v'", tc.c1, tc.layout, tc.c2, tc.equal)
-		}
+		assert.Equal(t, tc.equal, tc.c1.Equal(tc.layout, tc.c2))
 	}
 }
 
@@ -510,9 +502,7 @@ func TestLength(t *testing.T) {
 			want: 14,
 		},
 	} {
-		if got := tc.g.Length(); got != tc.want {
-			t.Errorf("%#v.Length() == %f, want %f", tc.g, got, tc.want)
-		}
+		assert.Equal(t, tc.want, tc.g.Length())
 	}
 }
 
@@ -548,8 +538,6 @@ func TestSetCoord(t *testing.T) {
 		},
 	} {
 		tc.dest.Set(tc.src)
-		if !tc.dest.Equal(tc.layout, tc.expected) {
-			t.Errorf("Setting %v with %v did not result in %v", tc.dest, tc.src, tc.dest)
-		}
+		assert.True(t, tc.dest.Equal(tc.layout, tc.expected))
 	}
 }

--- a/linearring_test.go
+++ b/linearring_test.go
@@ -1,147 +1,135 @@
 package geom
 
 import (
-	"reflect"
+	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // LinearRing implements interface T.
 var _ T = &LinearRing{}
 
-type testLinearRing struct {
+type expectedLinearRing struct {
 	layout     Layout
 	stride     int
-	coords     []Coord
 	flatCoords []float64
+	coords     []Coord
 	bounds     *Bounds
 }
 
-func testLinearRingEquals(t *testing.T, lr *LinearRing, tlr *testLinearRing) {
-	if err := lr.verify(); err != nil {
-		t.Error(err)
-	}
-	if lr.Layout() != tlr.layout {
-		t.Errorf("lr.Layout() == %v, want %v", lr.Layout(), tlr.layout)
-	}
-	if lr.Stride() != tlr.stride {
-		t.Errorf("lr.Stride() == %v, want %v", lr.Stride(), tlr.stride)
-	}
-	if !reflect.DeepEqual(lr.Coords(), tlr.coords) {
-		t.Errorf("lr.Coords() == %v, want %v", lr.Coords(), tlr.coords)
-	}
-	if !reflect.DeepEqual(lr.FlatCoords(), tlr.flatCoords) {
-		t.Errorf("lr.FlatCoords() == %v, want %v", lr.FlatCoords(), tlr.flatCoords)
-	}
-	if !reflect.DeepEqual(lr.Bounds(), tlr.bounds) {
-		t.Errorf("lr.Bounds() == %v, want %v", lr.Bounds(), tlr.bounds)
-	}
-	if got := lr.NumCoords(); got != len(tlr.coords) {
-		t.Errorf("lr.NumCoords() == %v, want %v", got, len(tlr.coords))
-	}
-	for i, c := range tlr.coords {
-		if !reflect.DeepEqual(lr.Coord(i), c) {
-			t.Errorf("lr.Coord(%v) == %v, want %v", i, lr.Coord(i), c)
-		}
+func (g *LinearRing) assertEquals(t *testing.T, e *expectedLinearRing) {
+	assert.NoError(t, g.verify())
+	assert.Equal(t, e.layout, g.Layout())
+	assert.Equal(t, e.stride, g.Stride())
+	assert.Equal(t, e.flatCoords, g.FlatCoords())
+	assert.Nil(t, g.Ends())
+	assert.Nil(t, g.Endss())
+	assert.Equal(t, e.coords, g.Coords())
+	assert.Equal(t, e.bounds, g.Bounds())
+	assert.Equal(t, len(e.coords), g.NumCoords())
+	for i, c := range e.coords {
+		assert.Equal(t, c, g.Coord(i))
 	}
 }
 
 func TestLinearRing(t *testing.T) {
-	for _, c := range []struct {
-		lr  *LinearRing
-		tlr *testLinearRing
+	for i, tc := range []struct {
+		lr       *LinearRing
+		expected *expectedLinearRing
 	}{
 		{
 			lr: NewLinearRing(XY).MustSetCoords([]Coord{{1, 2}, {3, 4}, {5, 6}}),
-			tlr: &testLinearRing{
+			expected: &expectedLinearRing{
 				layout:     XY,
 				stride:     2,
-				coords:     []Coord{{1, 2}, {3, 4}, {5, 6}},
 				flatCoords: []float64{1, 2, 3, 4, 5, 6},
+				coords:     []Coord{{1, 2}, {3, 4}, {5, 6}},
 				bounds:     NewBounds(XY).Set(1, 2, 5, 6),
 			},
 		},
 		{
 			lr: NewLinearRing(XYZ).MustSetCoords([]Coord{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}),
-			tlr: &testLinearRing{
+			expected: &expectedLinearRing{
 				layout:     XYZ,
 				stride:     3,
-				coords:     []Coord{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}},
 				flatCoords: []float64{1, 2, 3, 4, 5, 6, 7, 8, 9},
+				coords:     []Coord{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}},
 				bounds:     NewBounds(XYZ).Set(1, 2, 3, 7, 8, 9),
 			},
 		},
 		{
 			lr: NewLinearRing(XYM).MustSetCoords([]Coord{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}),
-			tlr: &testLinearRing{
+			expected: &expectedLinearRing{
 				layout:     XYM,
 				stride:     3,
-				coords:     []Coord{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}},
 				flatCoords: []float64{1, 2, 3, 4, 5, 6, 7, 8, 9},
+				coords:     []Coord{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}},
 				bounds:     NewBounds(XYM).Set(1, 2, 3, 7, 8, 9),
 			},
 		},
 		{
 			lr: NewLinearRing(XYZM).MustSetCoords([]Coord{{1, 2, 3, 4}, {5, 6, 7, 8}, {9, 10, 11, 12}}),
-			tlr: &testLinearRing{
+			expected: &expectedLinearRing{
 				layout:     XYZM,
 				stride:     4,
-				coords:     []Coord{{1, 2, 3, 4}, {5, 6, 7, 8}, {9, 10, 11, 12}},
 				flatCoords: []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
+				coords:     []Coord{{1, 2, 3, 4}, {5, 6, 7, 8}, {9, 10, 11, 12}},
 				bounds:     NewBounds(XYZM).Set(1, 2, 3, 4, 9, 10, 11, 12),
 			},
 		},
 	} {
-		testLinearRingEquals(t, c.lr, c.tlr)
-	}
-}
-
-func TestLinearRingClone(t *testing.T) {
-	p1 := NewLinearRing(XY).MustSetCoords([]Coord{{1, 2}, {3, 4}, {5, 6}})
-	if p2 := p1.Clone(); aliases(p1.FlatCoords(), p2.FlatCoords()) {
-		t.Error("Clone() should not alias flatCoords")
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			tc.lr.assertEquals(t, tc.expected)
+			assert.False(t, aliases(tc.lr.FlatCoords(), tc.lr.Clone().FlatCoords()))
+		})
 	}
 }
 
 func TestLinearRingStrideMismatch(t *testing.T) {
-	for _, c := range []struct {
-		layout Layout
-		coords []Coord
-		err    error
+	for i, tc := range []struct {
+		l        Layout
+		cs       []Coord
+		expected error
 	}{
 		{
-			layout: XY,
-			coords: nil,
-			err:    nil,
+			l:        XY,
+			cs:       nil,
+			expected: nil,
 		},
 		{
-			layout: XY,
-			coords: []Coord{},
-			err:    nil,
+			l:        XY,
+			cs:       []Coord{},
+			expected: nil,
 		},
 		{
-			layout: XY,
-			coords: []Coord{{1, 2}, {}},
-			err:    ErrStrideMismatch{Got: 0, Want: 2},
+			l:        XY,
+			cs:       []Coord{{1, 2}, {}},
+			expected: ErrStrideMismatch{Got: 0, Want: 2},
 		},
 		{
-			layout: XY,
-			coords: []Coord{{1, 2}, {1}},
-			err:    ErrStrideMismatch{Got: 1, Want: 2},
+			l:        XY,
+			cs:       []Coord{{1, 2}, {1}},
+			expected: ErrStrideMismatch{Got: 1, Want: 2},
 		},
 		{
-			layout: XY,
-			coords: []Coord{{1, 2}, {3, 4}},
-			err:    nil,
+			l:        XY,
+			cs:       []Coord{{1, 2}, {3, 4}},
+			expected: nil,
 		},
 		{
-			layout: XY,
-			coords: []Coord{{1, 2}, {3, 4, 5}},
-			err:    ErrStrideMismatch{Got: 3, Want: 2},
+			l:        XY,
+			cs:       []Coord{{1, 2}, {3, 4, 5}},
+			expected: ErrStrideMismatch{Got: 3, Want: 2},
 		},
 	} {
-		p := NewLinearRing(c.layout)
-		if _, err := p.SetCoords(c.coords); err != c.err {
-			t.Errorf("p.SetCoords(%v) == %v, want %v", c.coords, err, c.err)
-		}
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			_, err := NewLinearRing(tc.l).SetCoords(tc.cs)
+			assert.Equal(t, tc.expected, err)
+		})
 	}
+}
+
+func TestLinearRingSetSRID(t *testing.T) {
+	assert.Equal(t, 4326, NewLinearRing(NoLayout).SetSRID(4326).SRID())
 }

--- a/multilinestring_test.go
+++ b/multilinestring_test.go
@@ -1,164 +1,146 @@
 package geom
 
 import (
-	"reflect"
+	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // MultiLineString implements interface T.
 var _ T = &MultiLineString{}
 
-type testMultiLineString struct {
+type expectedMultiLineString struct {
 	layout     Layout
 	stride     int
-	coords     [][]Coord
 	flatCoords []float64
 	ends       []int
+	coords     [][]Coord
 	empty      bool
 	bounds     *Bounds
 }
 
-func testMultiLineStringEquals(t *testing.T, mls *MultiLineString, tmls *testMultiLineString) {
-	if err := mls.verify(); err != nil {
-		t.Error(err)
-	}
-	if mls.Layout() != tmls.layout {
-		t.Errorf("mls.Layout() == %v, want %v", mls.Layout(), tmls.layout)
-	}
-	if mls.Stride() != tmls.stride {
-		t.Errorf("mls.Stride() == %v, want %v", mls.Stride(), tmls.stride)
-	}
-	if !reflect.DeepEqual(mls.Coords(), tmls.coords) {
-		t.Errorf("mls.Coords() == %#v, want %#v", mls.Coords(), tmls.coords)
-	}
-	if !reflect.DeepEqual(mls.FlatCoords(), tmls.flatCoords) {
-		t.Errorf("mls.FlatCoords() == %#v, want %#v", mls.FlatCoords(), tmls.flatCoords)
-	}
-	if !reflect.DeepEqual(mls.Ends(), tmls.ends) {
-		t.Errorf("mls.Ends() == %#v, want %#v", mls.Ends(), tmls.ends)
-	}
-	if !reflect.DeepEqual(mls.Bounds(), tmls.bounds) {
-		t.Errorf("mls.Bounds() == %v, want %v", mls.Bounds(), tmls.bounds)
-	}
-	if mls.Empty() != tmls.empty {
-		t.Errorf("mls.Empty() == %t, want %t", mls.Empty(), tmls.empty)
-	}
-	if got := mls.NumLineStrings(); got != len(tmls.coords) {
-		t.Errorf("mls.NumLineStrings() == %v, want %v", got, len(tmls.coords))
-	}
-	for i, c := range tmls.coords {
-		want := NewLineString(mls.Layout()).MustSetCoords(c)
-		if got := mls.LineString(i); !reflect.DeepEqual(got, want) {
-			t.Errorf("mls.LineString(%v) == %v, want %v", i, got, want)
-		}
+func (g *MultiLineString) assertEquals(t *testing.T, e *expectedMultiLineString) {
+	assert.NoError(t, g.verify())
+	assert.Equal(t, e.layout, g.Layout())
+	assert.Equal(t, e.stride, g.Stride())
+	assert.Equal(t, e.flatCoords, g.FlatCoords())
+	assert.Equal(t, e.ends, g.Ends())
+	assert.Nil(t, g.Endss())
+	assert.Equal(t, e.coords, g.Coords())
+	assert.Equal(t, e.bounds, g.Bounds())
+	assert.Equal(t, e.empty, g.Empty())
+	assert.Equal(t, len(e.coords), g.NumLineStrings())
+	for i, c := range e.coords {
+		assert.Equal(t, NewLineString(g.Layout()).MustSetCoords(c), g.LineString(i))
 	}
 }
 
 func TestMultiLineString(t *testing.T) {
-	for _, c := range []struct {
-		mls  *MultiLineString
-		tmls *testMultiLineString
+	for i, tc := range []struct {
+		mls      *MultiLineString
+		expected *expectedMultiLineString
 	}{
 		{
 			mls: NewMultiLineString(XY).MustSetCoords([][]Coord{{{1, 2}, {3, 4}, {5, 6}}, {{7, 8}, {9, 10}, {11, 12}}}),
-			tmls: &testMultiLineString{
+			expected: &expectedMultiLineString{
 				layout:     XY,
 				stride:     2,
-				coords:     [][]Coord{{{1, 2}, {3, 4}, {5, 6}}, {{7, 8}, {9, 10}, {11, 12}}},
 				flatCoords: []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
 				ends:       []int{6, 12},
+				coords:     [][]Coord{{{1, 2}, {3, 4}, {5, 6}}, {{7, 8}, {9, 10}, {11, 12}}},
 				bounds:     NewBounds(XY).Set(1, 2, 11, 12),
 				empty:      false,
 			},
 		},
 		{
 			mls: NewMultiLineString(XY),
-			tmls: &testMultiLineString{
+			expected: &expectedMultiLineString{
 				layout:     XY,
 				stride:     2,
-				coords:     [][]Coord{},
 				flatCoords: nil,
 				ends:       nil,
+				coords:     [][]Coord{},
 				bounds:     NewBounds(XY),
 				empty:      true,
 			},
 		},
 		{
 			mls: NewMultiLineString(XY).MustSetCoords([][]Coord{{}, {}}),
-			tmls: &testMultiLineString{
+			expected: &expectedMultiLineString{
 				layout:     XY,
 				stride:     2,
-				coords:     [][]Coord{{}, {}},
 				flatCoords: nil,
 				ends:       []int{0, 0},
+				coords:     [][]Coord{{}, {}},
 				bounds:     NewBounds(XY),
 				empty:      true,
 			},
 		},
 		{
 			mls: NewMultiLineString(XY).MustSetCoords([][]Coord{{}, {}, {{1, 2}, {3, 4}, {5, 6}}, {{7, 8}, {9, 10}, {11, 12}}, {}}),
-			tmls: &testMultiLineString{
+			expected: &expectedMultiLineString{
 				layout:     XY,
 				stride:     2,
-				coords:     [][]Coord{{}, {}, {{1, 2}, {3, 4}, {5, 6}}, {{7, 8}, {9, 10}, {11, 12}}, {}},
 				flatCoords: []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
 				ends:       []int{0, 0, 6, 12, 12},
+				coords:     [][]Coord{{}, {}, {{1, 2}, {3, 4}, {5, 6}}, {{7, 8}, {9, 10}, {11, 12}}, {}},
 				bounds:     NewBounds(XY).Set(1, 2, 11, 12),
 				empty:      false,
 			},
 		},
 	} {
-		testMultiLineStringEquals(t, c.mls, c.tmls)
-	}
-}
-
-func TestMultiLineStringClone(t *testing.T) {
-	p1 := NewMultiLineString(XY).MustSetCoords([][]Coord{{{1, 2}, {3, 4}, {5, 6}}})
-	if p2 := p1.Clone(); aliases(p1.FlatCoords(), p2.FlatCoords()) {
-		t.Error("Clone() should not alias flatCoords")
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			tc.mls.assertEquals(t, tc.expected)
+			assert.False(t, aliases(tc.mls.FlatCoords(), tc.mls.Clone().FlatCoords()))
+		})
 	}
 }
 
 func TestMultiLineStringStrideMismatch(t *testing.T) {
-	for _, c := range []struct {
-		layout Layout
-		coords [][]Coord
-		err    error
+	for i, tc := range []struct {
+		l        Layout
+		cs       [][]Coord
+		expected error
 	}{
 		{
-			layout: XY,
-			coords: nil,
-			err:    nil,
+			l:        XY,
+			cs:       nil,
+			expected: nil,
 		},
 		{
-			layout: XY,
-			coords: [][]Coord{},
-			err:    nil,
+			l:        XY,
+			cs:       [][]Coord{},
+			expected: nil,
 		},
 		{
-			layout: XY,
-			coords: [][]Coord{{{1, 2}, {}}},
-			err:    ErrStrideMismatch{Got: 0, Want: 2},
+			l:        XY,
+			cs:       [][]Coord{{{1, 2}, {}}},
+			expected: ErrStrideMismatch{Got: 0, Want: 2},
 		},
 		{
-			layout: XY,
-			coords: [][]Coord{{{1, 2}, {1}}},
-			err:    ErrStrideMismatch{Got: 1, Want: 2},
+			l:        XY,
+			cs:       [][]Coord{{{1, 2}, {1}}},
+			expected: ErrStrideMismatch{Got: 1, Want: 2},
 		},
 		{
-			layout: XY,
-			coords: [][]Coord{{{1, 2}, {3, 4}}},
-			err:    nil,
+			l:        XY,
+			cs:       [][]Coord{{{1, 2}, {3, 4}}},
+			expected: nil,
 		},
 		{
-			layout: XY,
-			coords: [][]Coord{{{1, 2}, {3, 4, 5}}},
-			err:    ErrStrideMismatch{Got: 3, Want: 2},
+			l:        XY,
+			cs:       [][]Coord{{{1, 2}, {3, 4, 5}}},
+			expected: ErrStrideMismatch{Got: 3, Want: 2},
 		},
 	} {
-		mls := NewMultiLineString(c.layout)
-		if _, err := mls.SetCoords(c.coords); err != c.err {
-			t.Errorf("mls.SetCoords(%v) == %v, want %v", c.coords, err, c.err)
-		}
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			_, err := NewMultiLineString(tc.l).SetCoords(tc.cs)
+			assert.Equal(t, tc.expected, err)
+		})
 	}
+}
+
+func TestMultiLineStringSetSRID(t *testing.T) {
+	assert.Equal(t, 4326, NewMultiLineString(NoLayout).SetSRID(4326).SRID())
 }

--- a/point_test.go
+++ b/point_test.go
@@ -1,175 +1,164 @@
 package geom
 
 import (
-	"reflect"
+	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // Point implements interface T.
 var _ T = &Point{}
 
-type testPoint struct {
+type expectedPoint struct {
 	layout     Layout
 	stride     int
-	coords     Coord
 	flatCoords []float64
+	coords     Coord
 	bounds     *Bounds
 }
 
-func testPointEquals(t *testing.T, p *Point, tp *testPoint) {
-	if err := p.verify(); err != nil {
-		t.Error(err)
-	}
-	if p.Layout() != tp.layout {
-		t.Errorf("p.Layout() == %v, want %v", p.Layout(), tp.layout)
-	}
-	if p.Stride() != tp.stride {
-		t.Errorf("p.Stride() == %v, want %v", p.Stride(), tp.stride)
-	}
-	if !reflect.DeepEqual(p.Coords(), tp.coords) {
-		t.Errorf("p.Coords() == %v, want %v", p.Coords(), tp.coords)
-	}
-	if !reflect.DeepEqual(p.FlatCoords(), tp.flatCoords) {
-		t.Errorf("p.FlatCoords() == %v, want %v", p.FlatCoords(), tp.flatCoords)
-	}
-	if !reflect.DeepEqual(p.Bounds(), tp.bounds) {
-		t.Errorf("p.Bounds() == %v, want %v", p.Bounds(), tp.bounds)
-	}
+func (g *Point) assertEquals(t *testing.T, e *expectedPoint) {
+	assert.NoError(t, g.verify())
+	assert.Equal(t, e.layout, g.Layout())
+	assert.Equal(t, e.stride, g.Stride())
+	assert.Equal(t, e.flatCoords, g.FlatCoords())
+	assert.Nil(t, g.Ends())
+	assert.Nil(t, g.Endss())
+	assert.Equal(t, 1, g.NumCoords())
+	assert.Equal(t, e.coords, g.Coords())
+	assert.Equal(t, e.bounds, g.Bounds())
 }
 
 func TestPoint(t *testing.T) {
-	for _, c := range []struct {
-		p  *Point
-		tp *testPoint
+	for i, tc := range []struct {
+		p        *Point
+		expected *expectedPoint
 	}{
 		{
 			p: NewPoint(XY),
-			tp: &testPoint{
+			expected: &expectedPoint{
 				layout:     XY,
 				stride:     2,
-				coords:     Coord{0, 0},
 				flatCoords: []float64{0, 0},
+				coords:     Coord{0, 0},
 				bounds:     NewBounds(XY).Set(0, 0, 0, 0),
 			},
 		},
 		{
 			p: NewPoint(XY).MustSetCoords(Coord{1, 2}),
-			tp: &testPoint{
+			expected: &expectedPoint{
 				layout:     XY,
 				stride:     2,
-				coords:     Coord{1, 2},
 				flatCoords: []float64{1, 2},
+				coords:     Coord{1, 2},
 				bounds:     NewBounds(XY).Set(1, 2, 1, 2),
 			},
 		},
 		{
 			p: NewPoint(XYZ),
-			tp: &testPoint{
+			expected: &expectedPoint{
 				layout:     XYZ,
 				stride:     3,
-				coords:     Coord{0, 0, 0},
 				flatCoords: []float64{0, 0, 0},
+				coords:     Coord{0, 0, 0},
 				bounds:     NewBounds(XYZ).Set(0, 0, 0, 0, 0, 0),
 			},
 		},
 		{
 			p: NewPoint(XYZ).MustSetCoords(Coord{1, 2, 3}),
-			tp: &testPoint{
+			expected: &expectedPoint{
 				layout:     XYZ,
 				stride:     3,
-				coords:     Coord{1, 2, 3},
 				flatCoords: []float64{1, 2, 3},
+				coords:     Coord{1, 2, 3},
 				bounds:     NewBounds(XYZ).Set(1, 2, 3, 1, 2, 3),
 			},
 		},
 		{
 			p: NewPoint(XYM),
-			tp: &testPoint{
+			expected: &expectedPoint{
 				layout:     XYM,
 				stride:     3,
-				coords:     Coord{0, 0, 0},
 				flatCoords: []float64{0, 0, 0},
+				coords:     Coord{0, 0, 0},
 				bounds:     NewBounds(XYM).Set(0, 0, 0, 0, 0, 0),
 			},
 		},
 		{
 			p: NewPoint(XYM).MustSetCoords(Coord{1, 2, 3}),
-			tp: &testPoint{
+			expected: &expectedPoint{
 				layout:     XYM,
 				stride:     3,
-				coords:     Coord{1, 2, 3},
 				flatCoords: []float64{1, 2, 3},
+				coords:     Coord{1, 2, 3},
 				bounds:     NewBounds(XYM).Set(1, 2, 3, 1, 2, 3),
 			},
 		},
 		{
 			p: NewPoint(XYZM),
-			tp: &testPoint{
+			expected: &expectedPoint{
 				layout:     XYZM,
 				stride:     4,
-				coords:     Coord{0, 0, 0, 0},
 				flatCoords: []float64{0, 0, 0, 0},
+				coords:     Coord{0, 0, 0, 0},
 				bounds:     NewBounds(XYZM).Set(0, 0, 0, 0, 0, 0, 0, 0),
 			},
 		},
 		{
 			p: NewPoint(XYZM).MustSetCoords(Coord{1, 2, 3, 4}),
-			tp: &testPoint{
+			expected: &expectedPoint{
 				layout:     XYZM,
 				stride:     4,
-				coords:     Coord{1, 2, 3, 4},
 				flatCoords: []float64{1, 2, 3, 4},
+				coords:     Coord{1, 2, 3, 4},
 				bounds:     NewBounds(XYZM).Set(1, 2, 3, 4, 1, 2, 3, 4),
 			},
 		},
 	} {
-		testPointEquals(t, c.p, c.tp)
-	}
-}
-
-func TestPointClone(t *testing.T) {
-	p1 := NewPoint(XY).MustSetCoords(Coord{1, 2})
-	if p2 := p1.Clone(); aliases(p1.FlatCoords(), p2.FlatCoords()) {
-		t.Error("Clone() should not alias flatCoords")
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			tc.p.assertEquals(t, tc.expected)
+			assert.False(t, aliases(tc.p.FlatCoords(), tc.p.Clone().FlatCoords()))
+		})
 	}
 }
 
 func TestPointStrideMismatch(t *testing.T) {
-	for _, c := range []struct {
-		layout Layout
-		coords Coord
-		err    error
+	for i, tc := range []struct {
+		l        Layout
+		cs       Coord
+		expected error
 	}{
 		{
-			layout: XY,
-			coords: nil,
-			err:    ErrStrideMismatch{Got: 0, Want: 2},
+			l:        XY,
+			cs:       nil,
+			expected: ErrStrideMismatch{Got: 0, Want: 2},
 		},
 		{
-			layout: XY,
-			coords: Coord{},
-			err:    ErrStrideMismatch{Got: 0, Want: 2},
+			l:        XY,
+			cs:       Coord{},
+			expected: ErrStrideMismatch{Got: 0, Want: 2},
 		},
 		{
-			layout: XY,
-			coords: Coord{1},
-			err:    ErrStrideMismatch{Got: 1, Want: 2},
+			l:        XY,
+			cs:       Coord{1},
+			expected: ErrStrideMismatch{Got: 1, Want: 2},
 		},
 		{
-			layout: XY,
-			coords: Coord{1, 2},
-			err:    nil,
+			l:        XY,
+			cs:       Coord{1, 2},
+			expected: nil,
 		},
 		{
-			layout: XY,
-			coords: Coord{1, 2, 3},
-			err:    ErrStrideMismatch{Got: 3, Want: 2},
+			l:        XY,
+			cs:       Coord{1, 2, 3},
+			expected: ErrStrideMismatch{Got: 3, Want: 2},
 		},
 	} {
-		p := NewPoint(c.layout)
-		if _, err := p.SetCoords(c.coords); err != c.err {
-			t.Errorf("p.SetCoords(%v) == %v, want %v", c.coords, err, c.err)
-		}
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			_, err := NewPoint(tc.l).SetCoords(tc.cs)
+			assert.Equal(t, tc.expected, err)
+		})
 	}
 }
 
@@ -179,51 +168,19 @@ func TestPointCloneAndSwap(t *testing.T) {
 	p1Clone := p1.Clone()
 	p2Clone := p2.Clone()
 	p1.Swap(p2)
-	if !reflect.DeepEqual(p1, p2Clone) {
-		t.Errorf("p1 == %v, want %v", p1, p2Clone)
-	}
-	if !reflect.DeepEqual(p2, p1Clone) {
-		t.Errorf("p2 == %v, want %v", p2, p1Clone)
-	}
+	assert.Equal(t, p1, p2Clone)
+	assert.Equal(t, p2, p1Clone)
 	p1.Swap(p2)
-	if !reflect.DeepEqual(p1, p1Clone) {
-		t.Errorf("p1 == %v, want %v", p1, p1Clone)
-	}
-	if !reflect.DeepEqual(p2, p2Clone) {
-		t.Errorf("p2 == %v, want %v", p2, p2Clone)
-	}
-}
-
-func TestPointEnds(t *testing.T) {
-	p := NewPoint(XY).MustSetCoords(Coord{1, 2})
-	if got := p.Ends(); got != nil {
-		t.Errorf("p.Ends() == %v, want <nil>", got)
-	}
-}
-
-func TestPointEndss(t *testing.T) {
-	p := NewPoint(XY).MustSetCoords(Coord{1, 2})
-	if got := p.Endss(); got != nil {
-		t.Errorf("p.Endss() == %v, want <nil>", got)
-	}
-}
-
-func TestPointNumCoords(t *testing.T) {
-	p := NewPoint(XY).MustSetCoords(Coord{1, 2})
-	if got, want := p.NumCoords(), 1; got != want {
-		t.Errorf("p.NumCoords() == %d, want %d", got, want)
-	}
+	assert.Equal(t, p1, p1Clone)
+	assert.Equal(t, p2, p2Clone)
 }
 
 func TestPointSetSRID(t *testing.T) {
-	p := NewPoint(XY).SetSRID(4326)
-	if got, want := p.SRID(), 4326; got != want {
-		t.Errorf("p.SRID() == %d, want %d", got, want)
-	}
+	assert.Equal(t, 4326, NewPoint(XY).SetSRID(4326).SRID())
 }
 
 func TestPointXYZM(t *testing.T) {
-	for _, tc := range []struct {
+	for i, tc := range []struct {
 		p          *Point
 		x, y, z, m float64
 	}{
@@ -252,17 +209,11 @@ func TestPointXYZM(t *testing.T) {
 			m: 4,
 		},
 	} {
-		if got := tc.p.X(); got != tc.x {
-			t.Errorf("%v.X() == %f, want %f", tc.p, got, tc.x)
-		}
-		if got := tc.p.Y(); got != tc.y {
-			t.Errorf("%v.Y() == %f, want %f", tc.p, got, tc.y)
-		}
-		if got := tc.p.Z(); got != tc.z {
-			t.Errorf("%v.Z() == %f, want %f", tc.p, got, tc.z)
-		}
-		if got := tc.p.M(); got != tc.m {
-			t.Errorf("%v.M() == %f, want %f", tc.p, got, tc.m)
-		}
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			assert.Equal(t, tc.x, tc.p.X())
+			assert.Equal(t, tc.y, tc.p.Y())
+			assert.Equal(t, tc.z, tc.p.Z())
+			assert.Equal(t, tc.m, tc.p.M())
+		})
 	}
 }


### PR DESCRIPTION
This PR moves to `github.com/stretchr/testify` for tests, which is significantly easier to use that Go's standard `testing` library, and provides nicer error messages when complex values differ.

Not all tests are ported yet.