### PR TITLE
fix convex hull panic

### DIFF
--- a/xy/convex_hull.go
+++ b/xy/convex_hull.go
@@ -237,9 +237,21 @@ func (calc *convexHullCalculator) computeOctRing(inputPts []float64) []float64 {
 	}
 
 	copyTo += stride
-	octPts = octPts[0 : copyTo+stride]
+
+	// if ring already closed, just return
+	if internal.Equal(octPts, copyTo-stride, octPts, 0) {
+		return octPts
+	}
 
 	// close ring
+	// make sure there is enough capacity
+	if len(octPts) < copyTo+stride {
+		t := make([]float64, copyTo+stride)
+		copy(t, octPts)
+		octPts = t
+	}
+	octPts = octPts[0 : copyTo+stride]
+
 	for j := 0; j < stride; j++ {
 		octPts[copyTo+j] = octPts[j]
 	}

--- a/xy/convex_hull_test.go
+++ b/xy/convex_hull_test.go
@@ -174,6 +174,34 @@ func TestOctRing(t *testing.T) {
 	}
 }
 
+func TestOctRingPanic(t *testing.T) {
+	flat := []float64{
+		1, 1,
+		1, 2,
+		2, 3,
+		3, 3,
+		4, 2,
+		4, 1,
+		3, 0,
+		2, 0,
+	}
+	calc := convexHullCalculator{layout: geom.XYM, stride: 2}
+	got := calc.computeOctRing(flat)
+	expected := []float64{
+		1, 1,
+		1, 2,
+		2, 3,
+		3, 3,
+		4, 2,
+		4, 1,
+		3, 0,
+		1, 1,
+	}
+	if !reflect.DeepEqual(expected, got) {
+		t.Fatalf("calc.computeOctRing failed. Expected \n\t%v\nbut was \n\t%v", expected, got)
+	}
+}
+
 func TestGrahamScan(t *testing.T) {
 	calc := &convexHullCalculator{layout: geom.XY, stride: 2}
 	coords := append([]float64{}, internal.RING.FlatCoords()...)


### PR DESCRIPTION
fix #146 

I believe this is happening because the points returned by calc.computeOctPts is already the 8 distinct points. so the copyTo is already 8 * stride, and panic happens when trying to extend the capacity to 9 * stride when closing the ring.

Trying to push a naive fix. I still feel the problem is inside calc.computeOctPts