### PR TITLE
encoding: support GEOMETRYCOLLECTION EMPTY wkb/ewkb writes

### DIFF
--- a/encoding/ewkb/ewkb.go
+++ b/encoding/ewkb/ewkb.go
@@ -224,6 +224,11 @@ func Write(w io.Writer, byteOrder binary.ByteOrder, g geom.T) error {
 		return geom.ErrUnsupportedType{Value: g}
 	}
 	switch g.Layout() {
+	case geom.NoLayout:
+		// Special case for empty GeometryCollections
+		if g, ok := g.(*geom.GeometryCollection); !ok || !g.Empty() {
+			return geom.ErrUnsupportedLayout(g.Layout())
+		}
 	case geom.XY:
 	case geom.XYZ:
 		ewkbGeometryType |= ewkbZ

--- a/encoding/ewkb/ewkb_test.go
+++ b/encoding/ewkb/ewkb_test.go
@@ -210,6 +210,11 @@ func Test(t *testing.T) {
 			ndr: mustDecodeString("01010000e0e6100000000000000000f03f000000000000004000000000000008400000000000001040"),
 		},
 		{
+			g:   geom.NewGeometryCollection().SetSRID(4326),
+			xdr: mustDecodeString("0020000007000010e600000000"),
+			ndr: mustDecodeString("0107000020e610000000000000"),
+		},
+		{
 			g: geom.NewGeometryCollection().SetSRID(4326).MustPush(
 				geom.NewPoint(geom.XY).MustSetCoords(geom.Coord{1, 2}),
 				geom.NewLineString(geom.XY).MustSetCoords([]geom.Coord{{3, 4}, {5, 6}}),

--- a/encoding/wkb/wkb.go
+++ b/encoding/wkb/wkb.go
@@ -213,6 +213,11 @@ func Write(w io.Writer, byteOrder binary.ByteOrder, g geom.T) error {
 		return geom.ErrUnsupportedType{Value: g}
 	}
 	switch g.Layout() {
+	case geom.NoLayout:
+		// Special case for empty GeometryCollections
+		if g, ok := g.(*geom.GeometryCollection); !ok || !g.Empty() {
+			return geom.ErrUnsupportedLayout(g.Layout())
+		}
 	case geom.XY:
 		wkbGeometryType += wkbXYID
 	case geom.XYZ:

--- a/encoding/wkb/wkb_test.go
+++ b/encoding/wkb/wkb_test.go
@@ -245,6 +245,11 @@ func Test(t *testing.T) {
 			ndr: geomtest.MustHexDecode("01bc0b00000200000001b90b0000000000000000f03f00000000000000400000000000000840000000000000104001b90b0000000000000000144000000000000018400000000000001c400000000000002040"),
 		},
 		{
+			g:   geom.NewGeometryCollection(),
+			xdr: geomtest.MustHexDecode("000000000700000000"),
+			ndr: geomtest.MustHexDecode("010700000000000000"),
+		},
+		{
 			g: geom.NewGeometryCollection().MustPush(
 				geom.NewPoint(geom.XY).MustSetCoords(geom.Coord{-79.3698576, 43.6456613}),
 				geom.NewLineString(geom.XY).MustSetCoords([]geom.Coord{{-79.3707986, 43.6453697}, {-79.3704747, 43.6454819}, {-79.370186, 43.6455592}, {-79.3699323, 43.6456385}, {-79.3698576, 43.6456613}}),


### PR DESCRIPTION
This follows the WKT encoding protocol allowing GEOMETRYCOLLECTION EMPTY to be written as WKB and EWKB.

cc https://github.com/cockroachdb/cockroach/issues/48533