### PR TITLE
golangci-lint: fix lint failing on master

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,9 @@ linters:
     - gocognit
     - gocyclo
     - godox
+    - godot
     - gomnd
     - lll
+    - nestif
+    - testpackage
     - wsl

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ generate:
 
 .PHONY: install-tools
 install-tools:
-	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- v1.24.0
+	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- v1.25.0
 	GO111MODULE=off go get -u \
 		github.com/awalterschulze/goderive \
 		github.com/mattn/goveralls \

--- a/encoding/ewkb/ewkb_test.go
+++ b/encoding/ewkb/ewkb_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/twpayne/go-geom"
 )
 
-func test(t *testing.T, g geom.T, xdr []byte, ndr []byte) {
+func test(t *testing.T, g geom.T, xdr, ndr []byte) {
 	if xdr != nil {
 		if got, err := Unmarshal(xdr); err != nil || !reflect.DeepEqual(got, g) {
 			t.Errorf("Unmarshal(%s) == %#v, %#v, want %#v, nil", hex.EncodeToString(xdr), got, err, g)

--- a/encoding/ewkbhex/ewkbhex_test.go
+++ b/encoding/ewkbhex/ewkbhex_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/twpayne/go-geom/encoding/wkbcommon"
 )
 
-func test(t *testing.T, g geom.T, xdr string, ndr string) {
+func test(t *testing.T, g geom.T, xdr, ndr string) {
 	if xdr != "" {
 		if got, err := Decode(xdr); err != nil || !reflect.DeepEqual(got, g) {
 			t.Errorf("Decode(%s) == %#v, %#v, want %#v, nil", xdr, got, err, g)

--- a/encoding/wkb/wkb_test.go
+++ b/encoding/wkb/wkb_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/twpayne/go-geom/internal/testdata"
 )
 
-func test(t *testing.T, g geom.T, xdr []byte, ndr []byte) {
+func test(t *testing.T, g geom.T, xdr, ndr []byte) {
 	if xdr != nil {
 		if got, err := Unmarshal(xdr); err != nil || !reflect.DeepEqual(got, g) {
 			t.Errorf("Unmarshal(%s) == %#v, %#v, want %#v, nil", hex.EncodeToString(xdr), got, err, g)


### PR DESCRIPTION
* Upgrade to v1.25.0, which prevents the bad interface check.
* Added godot, nestif, testpackage, which was failing before this
commit.
* Fix goimports formatting.

