### PR TITLE
add SetSRID to T interface and add interface assertions

### DIFF
--- a/geom.go
+++ b/geom.go
@@ -128,6 +128,7 @@ type T interface {
 	Ends() []int
 	Endss() [][]int
 	SRID() int
+	SetSRID(int)
 }
 
 // MIndex returns the index of the M dimension, or -1 if the l does not have an

--- a/geometrycollection.go
+++ b/geometrycollection.go
@@ -7,6 +7,9 @@ type GeometryCollection struct {
 	srid  int
 }
 
+// GeometryCollection implements interface T.
+var _ T = (*GeometryCollection)(nil)
+
 // NewGeometryCollection returns a new empty GeometryCollection.
 func NewGeometryCollection() *GeometryCollection {
 	return &GeometryCollection{}

--- a/linearring.go
+++ b/linearring.go
@@ -5,6 +5,9 @@ type LinearRing struct {
 	geom1
 }
 
+// LinearRing implements interface T.
+var _ T = (*LinearRing)(nil)
+
 // NewLinearRing returns a new LinearRing with no coordinates.
 func NewLinearRing(layout Layout) *LinearRing {
 	return NewLinearRingFlat(layout, nil)

--- a/linestring.go
+++ b/linestring.go
@@ -6,6 +6,9 @@ type LineString struct {
 	geom1
 }
 
+// MultiLineString implements interface T.
+var _ T = (*MultiLineString)(nil)
+
 // NewLineString returns a new LineString with layout l and no control points.
 func NewLineString(l Layout) *LineString {
 	return NewLineStringFlat(l, nil)

--- a/multilinestring.go
+++ b/multilinestring.go
@@ -5,6 +5,9 @@ type MultiLineString struct {
 	geom2
 }
 
+// MultiLineString implements interface T.
+var _ T = (*MultiLineString)(nil)
+
 // NewMultiLineString returns a new MultiLineString with no LineStrings.
 func NewMultiLineString(layout Layout) *MultiLineString {
 	return NewMultiLineStringFlat(layout, nil, nil)

--- a/multipoint.go
+++ b/multipoint.go
@@ -5,6 +5,9 @@ type MultiPoint struct {
 	geom1
 }
 
+// MultiPoint implements interface T.
+var _ T = (*MultiPoint)(nil)
+
 // NewMultiPoint returns a new, empty, MultiPoint.
 func NewMultiPoint(layout Layout) *MultiPoint {
 	return NewMultiPointFlat(layout, nil)

--- a/multipolygon.go
+++ b/multipolygon.go
@@ -5,6 +5,9 @@ type MultiPolygon struct {
 	geom3
 }
 
+// MultiPolygon implements interface T.
+var _ T = (*MultiPolygon)(nil)
+
 // NewMultiPolygon returns a new MultiPolygon with no Polygons.
 func NewMultiPolygon(layout Layout) *MultiPolygon {
 	return NewMultiPolygonFlat(layout, nil, nil)

--- a/point.go
+++ b/point.go
@@ -5,6 +5,9 @@ type Point struct {
 	geom0
 }
 
+// MultiPoint implements interface T.
+var _ T = (*MultiPoint)(nil)
+
 // NewPoint allocates a new Point with layout l and all values zero.
 func NewPoint(l Layout) *Point {
 	return NewPointFlat(l, make([]float64, l.Stride()))

--- a/polygon.go
+++ b/polygon.go
@@ -7,6 +7,9 @@ type Polygon struct {
 	geom2
 }
 
+// Polygon implements interface T.
+var _ T = (*Polygon)(nil)
+
 // NewPolygon returns a new, empty, Polygon.
 func NewPolygon(layout Layout) *Polygon {
 	return NewPolygonFlat(layout, nil, nil)


### PR DESCRIPTION
* Add SetSRID to interface. This is a useful operation to us and we
cannot currently do it without type switches: https://github.com/cockroachdb/cockroach/blob/95549f51f008f7f9ad2095a06cc67e6ff964be02/pkg/geo/parse.go#L115
* Add interface assertions for all the types, makes unimplemented
interface errors easier to read at compile time.