### PR TITLE
GeoJSON: Added DecodeGeoJSON to directly decode GeoJSON bytes to geo types

### DIFF
--- a/encoding/geojson/geojson.go
+++ b/encoding/geojson/geojson.go
@@ -4,6 +4,7 @@ package geojson
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	geom "github.com/twpayne/go-geom"
@@ -30,11 +31,7 @@ func (e ErrUnsupportedType) Error() string {
 }
 
 // ErrEmptyData is returned when directly decoding empty GeoJSON bytes.
-type ErrEmptyData string
-
-func (e ErrEmptyData) Error() string {
-	return fmt.Sprintf("geojson: empty source data")
-}
+var ErrEmptyData = errors.New("geojson: empty source data")
 
 // A Geometry is a geometry in GeoJSON format.
 type Geometry struct {
@@ -213,7 +210,7 @@ func (g *Geometry) Decode() (geom.T, error) {
 // DecodeGeoJSON returns an arbitrary decoded geometry after unmarshalling the bytes to an intermediate GeoJSON.
 func DecodeGeoJSON(data []byte) (interface{}, error) {
 	if data == nil || bytes.Equal(data, nullGeometry) {
-		return nil, ErrEmptyData("")
+		return nil, ErrEmptyData
 	}
 	gg := &Geometry{}
 	if err := json.Unmarshal(data, gg); err != nil {

--- a/encoding/geojson/geojson.go
+++ b/encoding/geojson/geojson.go
@@ -210,10 +210,9 @@ func (g *Geometry) Decode() (geom.T, error) {
 	}
 }
 
-// DecodeGeoJSON returns an arbitrary decoded geometry after
-// unmarshalling the bytes to an intermediate GeoJSON
+// DecodeGeoJSON returns an arbitrary decoded geometry after unmarshalling the bytes to an intermediate GeoJSON.
 func DecodeGeoJSON(data []byte) (interface{}, error) {
-	if data == nil || len(data) == 0 || bytes.Equal(data, nullGeometry) {
+	if data == nil || bytes.Equal(data, nullGeometry) {
 		return nil, ErrEmptyData("")
 	}
 	gg := &Geometry{}

--- a/encoding/geojson/geojson.go
+++ b/encoding/geojson/geojson.go
@@ -29,7 +29,7 @@ func (e ErrUnsupportedType) Error() string {
 	return fmt.Sprintf("geojson: unsupported type: %s", string(e))
 }
 
-// ErrEmptyData is returned when directly decoding empty GeoJSON bytes
+// ErrEmptyData is returned when directly decoding empty GeoJSON bytes.
 type ErrEmptyData string
 
 func (e ErrEmptyData) Error() string {

--- a/encoding/geojson/geojson_test.go
+++ b/encoding/geojson/geojson_test.go
@@ -289,6 +289,7 @@ func TestFeatureCollection(t *testing.T) {
 }
 
 func TestDecodeGeoJSON(t *testing.T) {
+	// test proper decoding
 	test := `{"type":"Point","coordinates":[-71.09981854336587,42.327161019017154]}`
 	val, err := DecodeGeoJSON([]byte(test))
 	if err != nil {
@@ -296,6 +297,17 @@ func TestDecodeGeoJSON(t *testing.T) {
 	}
 
 	if _, ok := val.(*geom.Point); !ok {
-		t.Errorf("DecodeJson(%v), improper decoding, wanted point, got:\n%v", test, val)
+		t.Errorf("DecodeGeoJSON(%v), improper decoding, wanted point, got:\n%v", test, val)
+	}
+
+	// test bad decoding
+	test2 := `{"type":"LineString","coordinates":[-71.09981854336587,42.327161019017154]}`
+	val2, err := DecodeGeoJSON([]byte(test2))
+	if err == nil {
+		t.Error(err)
+	}
+
+	if _, ok := val2.(*geom.Point); ok {
+		t.Errorf("DecodeGeoJSON(%v), proper decoding, should fail", test2)
 	}
 }

--- a/encoding/geojson/geojson_test.go
+++ b/encoding/geojson/geojson_test.go
@@ -287,3 +287,15 @@ func TestFeatureCollection(t *testing.T) {
 		}
 	}
 }
+
+func TestDecodeGeoJSON(t *testing.T) {
+	test := `{"type":"Point","coordinates":[-71.09981854336587,42.327161019017154]}`
+	val, err := DecodeGeoJSON([]byte(test))
+	if err != nil {
+		t.Error(err)
+	}
+
+	if _, ok := val.(*geom.Point); !ok {
+		t.Errorf("DecodeJson(%v), improper decoding, wanted point, got:\n%v", test, val)
+	}
+}


### PR DESCRIPTION
This implementation returns an interface{} directly to avoid the shaded geo.T type. Due to the architecture of the geo types in this library, a geo.T cannot be easily be type asserted directly into the other types. Returning an interface{} here instead of a geo.T sidesteps that limitation and allows the consuming program to type check and assert properly to the underlying geo type.