### PR TITLE
add Empty to T interface and correct Empty for GeometryCollection

### DIFF
--- a/geom.go
+++ b/geom.go
@@ -128,6 +128,7 @@ type T interface {
 	Ends() []int
 	Endss() [][]int
 	SRID() int
+	Empty() bool
 }
 
 // MIndex returns the index of the M dimension, or -1 if the l does not have an

--- a/geometrycollection.go
+++ b/geometrycollection.go
@@ -70,8 +70,15 @@ func (g *GeometryCollection) Bounds() *Bounds {
 }
 
 // Empty returns true if the collection is empty.
+// This can return true if the GeometryCollection contains multiple Geometry objects
+// which are all empty.
 func (g *GeometryCollection) Empty() bool {
-	return len(g.geoms) == 0
+	for _, g := range g.geoms {
+		if !g.Empty() {
+			return false
+		}
+	}
+	return true
 }
 
 // FlatCoords panics.

--- a/geometrycollection_test.go
+++ b/geometrycollection_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 )
 
+// GeometryCollection implements interface T.
+var _ T = &GeometryCollection{}
+
 func TestGeometryCollectionBounds(t *testing.T) {
 	for _, tc := range []struct {
 		geoms []T
@@ -57,6 +60,45 @@ func TestGeometryCollectionBounds(t *testing.T) {
 		if got := NewGeometryCollection().MustPush(tc.geoms...).Bounds(); !reflect.DeepEqual(got, tc.want) {
 			t.Errorf("NewGeometryCollection().MustPush(%+v).Bounds() == %+v, want %+v", tc.geoms, got, tc.want)
 		}
+	}
+}
+
+func TestGeometryCollectionEmpty(t *testing.T) {
+	for _, tc := range []struct {
+		desc     string
+		geoms    []T
+		expected bool
+	}{
+		{
+			desc:     "empty GEOMETRYCOLLECTION",
+			geoms:    []T{},
+			expected: true,
+		},
+		{
+			desc:     "GEOMETRYCOLLECTION with all EMPTY geometries",
+			geoms:    []T{NewLineString(XY), NewPolygon(XY)},
+			expected: true,
+		},
+		{
+			desc:     "GEOMETRYCOLLECTION with one EMPTY object",
+			geoms:    []T{NewLineString(XY), NewPointFlat(XY, []float64{1, 2})},
+			expected: false,
+		},
+		{
+			desc:     "GEOMETRYCOLLECTION with no EMPTY object",
+			geoms:    []T{NewPointFlat(XY, []float64{1, 2})},
+			expected: false,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			gc := NewGeometryCollection()
+			for _, g := range tc.geoms {
+				gc.MustPush(g)
+			}
+			if got := gc.Empty(); got != tc.expected {
+				t.Errorf("%s: got %v, want %v", tc.desc, got, tc.expected)
+			}
+		})
 	}
 }
 

--- a/linearring_test.go
+++ b/linearring_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 )
 
+// LinearRing implements interface T.
+var _ T = &LinearRing{}
+
 type testLinearRing struct {
 	layout     Layout
 	stride     int

--- a/linestring_test.go
+++ b/linestring_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 )
 
+// MultiLineString implements interface T.
+var _ T = &MultiLineString{}
+
 type testLineString struct {
 	layout     Layout
 	stride     int

--- a/multilinestring_test.go
+++ b/multilinestring_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 )
 
+// MultiLineString implements interface T.
+var _ T = &MultiLineString{}
+
 type testMultiLineString struct {
 	layout     Layout
 	stride     int

--- a/multipoint_test.go
+++ b/multipoint_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 )
 
+// MultiPoint implements interface T.
+var _ T = &MultiPoint{}
+
 type testMultiPoint struct {
 	layout     Layout
 	stride     int

--- a/multipolygon_test.go
+++ b/multipolygon_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 )
 
+// MultiPolygon implements interface T.
+var _ T = &MultiPolygon{}
+
 type testMultiPolygon struct {
 	layout     Layout
 	stride     int

--- a/point_test.go
+++ b/point_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 )
 
+// Point implements interface T.
+var _ T = &Point{}
+
 type testPoint struct {
 	layout     Layout
 	stride     int

--- a/polygon_test.go
+++ b/polygon_test.go
@@ -6,6 +6,9 @@ import (
 	"testing"
 )
 
+// Polygon implements interface T.
+var _ T = &Polygon{}
+
 func ExampleNewPolygon() {
 	unitSquare := NewPolygon(XY).MustSetCoords([][]Coord{
 		{{0, 0}, {1, 0}, {1, 1}, {0, 1}, {0, 0}},


### PR DESCRIPTION
* Add Empty() to the T interface, which is defined on all geom.T types.
* Add interface assertions for all the types, makes unimplemented
interface errors easier to read at compile time.
* In PostGIS (at least), its possible for a GeometryCollection to have
multiple Empty elements and still be considered empty, e.g.
`GEOMETRYCOLLECTION(POINT EMPTY, LINESTRING EMPTY)`. This check changes
the Empty check such that GeometryCollection's Empty() also checks for
these cases.

