### PR TITLE
encoding/wkb,encoding/ewkb: fix encoding for POINT EMPTY

### DIFF
--- a/encoding/ewkb/ewkb.go
+++ b/encoding/ewkb/ewkb.go
@@ -78,6 +78,9 @@ func Read(r io.Reader) (geom.T, error) {
 		if err != nil {
 			return nil, err
 		}
+		if wkbcommon.IsEmptyPoint(flatCoords) {
+			return geom.NewPointEmpty(layout).SetSRID(int(srid)), nil
+		}
 		return geom.NewPointFlat(layout, flatCoords).SetSRID(int(srid)), nil
 	case wkbcommon.LineStringID:
 		flatCoords, err := wkbcommon.ReadFlatCoords1(r, byteOrder, layout.Stride())
@@ -254,6 +257,9 @@ func Write(w io.Writer, byteOrder binary.ByteOrder, g geom.T) error {
 
 	switch g := g.(type) {
 	case *geom.Point:
+		if g.Empty() {
+			return wkbcommon.WriteEmptyPoint(w, byteOrder, g.Stride())
+		}
 		return wkbcommon.WriteFlatCoords0(w, byteOrder, g.FlatCoords())
 	case *geom.LineString:
 		return wkbcommon.WriteFlatCoords1(w, byteOrder, g.FlatCoords(), g.Stride())

--- a/encoding/ewkb/ewkb_test.go
+++ b/encoding/ewkb/ewkb_test.go
@@ -170,6 +170,36 @@ func Test(t *testing.T) {
 		ndr []byte
 	}{
 		{
+			g:   geom.NewPointEmpty(geom.XY),
+			xdr: mustDecodeString("00000000017ff80000000000007ff8000000000000"),
+			ndr: mustDecodeString("0101000000000000000000f87f000000000000f87f"),
+		},
+		{
+			g:   geom.NewPointEmpty(geom.XYM),
+			xdr: mustDecodeString("00400000017ff80000000000007ff80000000000007ff8000000000000"),
+			ndr: mustDecodeString("0101000040000000000000f87f000000000000f87f000000000000f87f"),
+		},
+		{
+			g:   geom.NewPointEmpty(geom.XYZ),
+			xdr: mustDecodeString("00800000017ff80000000000007ff80000000000007ff8000000000000"),
+			ndr: mustDecodeString("0101000080000000000000f87f000000000000f87f000000000000f87f"),
+		},
+		{
+			g:   geom.NewPointEmpty(geom.XYZM),
+			xdr: mustDecodeString("00c00000017ff80000000000007ff80000000000007ff80000000000007ff8000000000000"),
+			ndr: mustDecodeString("01010000c0000000000000f87f000000000000f87f000000000000f87f000000000000f87f"),
+		},
+		{
+			g:   geom.NewGeometryCollection().MustPush(geom.NewPointEmpty(geom.XY)),
+			xdr: mustDecodeString("00000000070000000100000000017ff80000000000007ff8000000000000"),
+			ndr: mustDecodeString("0107000000010000000101000000000000000000f87f000000000000f87f"),
+		},
+		{
+			g:   geom.NewPointEmpty(geom.XY).SetSRID(4326),
+			xdr: mustDecodeString("0020000001000010e67ff80000000000007ff8000000000000"),
+			ndr: mustDecodeString("0101000020e6100000000000000000f87f000000000000f87f"),
+		},
+		{
 			g:   geom.NewPoint(geom.XY).MustSetCoords(geom.Coord{1, 2}),
 			xdr: mustDecodeString("00000000013ff00000000000004000000000000000"),
 			ndr: mustDecodeString("0101000000000000000000f03f0000000000000040"),

--- a/encoding/wkb/wkb.go
+++ b/encoding/wkb/wkb.go
@@ -70,6 +70,9 @@ func Read(r io.Reader) (geom.T, error) {
 		if err != nil {
 			return nil, err
 		}
+		if wkbcommon.IsEmptyPoint(flatCoords) {
+			return geom.NewPointEmpty(layout), nil
+		}
 		return geom.NewPointFlat(layout, flatCoords), nil
 	case wkbcommon.LineStringID:
 		flatCoords, err := wkbcommon.ReadFlatCoords1(r, byteOrder, layout.Stride())
@@ -235,6 +238,9 @@ func Write(w io.Writer, byteOrder binary.ByteOrder, g geom.T) error {
 
 	switch g := g.(type) {
 	case *geom.Point:
+		if g.Empty() {
+			return wkbcommon.WriteEmptyPoint(w, byteOrder, g.Stride())
+		}
 		return wkbcommon.WriteFlatCoords0(w, byteOrder, g.FlatCoords())
 	case *geom.LineString:
 		return wkbcommon.WriteFlatCoords1(w, byteOrder, g.FlatCoords(), g.Stride())

--- a/encoding/wkb/wkb_test.go
+++ b/encoding/wkb/wkb_test.go
@@ -165,6 +165,31 @@ func Test(t *testing.T) {
 		ndr []byte
 	}{
 		{
+			g:   geom.NewPointEmpty(geom.XY),
+			xdr: geomtest.MustHexDecode("00000000017ff80000000000007ff8000000000000"),
+			ndr: geomtest.MustHexDecode("0101000000000000000000f87f000000000000f87f"),
+		},
+		{
+			g:   geom.NewPointEmpty(geom.XYM),
+			xdr: geomtest.MustHexDecode("00000007d17ff80000000000007ff80000000000007ff8000000000000"),
+			ndr: geomtest.MustHexDecode("01d1070000000000000000f87f000000000000f87f000000000000f87f"),
+		},
+		{
+			g:   geom.NewPointEmpty(geom.XYZ),
+			xdr: geomtest.MustHexDecode("00000003e97ff80000000000007ff80000000000007ff8000000000000"),
+			ndr: geomtest.MustHexDecode("01e9030000000000000000f87f000000000000f87f000000000000f87f"),
+		},
+		{
+			g:   geom.NewPointEmpty(geom.XYZM),
+			xdr: geomtest.MustHexDecode("0000000bb97ff80000000000007ff80000000000007ff80000000000007ff8000000000000"),
+			ndr: geomtest.MustHexDecode("01b90b0000000000000000f87f000000000000f87f000000000000f87f000000000000f87f"),
+		},
+		{
+			g:   geom.NewGeometryCollection().MustPush(geom.NewPointEmpty(geom.XY)),
+			xdr: geomtest.MustHexDecode("00000000070000000100000000017ff80000000000007ff8000000000000"),
+			ndr: geomtest.MustHexDecode("0107000000010000000101000000000000000000f87f000000000000f87f"),
+		},
+		{
 			g:   geom.NewPoint(geom.XY).MustSetCoords(geom.Coord{1, 2}),
 			xdr: geomtest.MustHexDecode("00000000013ff00000000000004000000000000000"),
 			ndr: geomtest.MustHexDecode("0101000000000000000000f03f0000000000000040"),


### PR DESCRIPTION
For POINT EMPTY, NaN is used as the XYZM values in WKB/EWKB encoding.

See Requirement 152 of http://www.geopackage.org/spec/:

```
If the geometry is a Point, it SHALL be encoded with each coordinate value set to an IEEE-754 quiet NaN value. GeoPackages SHALL use big endian 0x7ff8000000000000 or little endian 0x000000000000f87f as the binary encoding of the NaN values. (This is because Well-Known Binary as defined in OGC 06-103r4 [9] does not provide a standardized encoding for an empty point set, i.e., 'Point Empty' in Well-Known Text.)
```

This commit addresses that behaviour.

NOTE: this may be the wrong way of doing it, and we should do it like https://github.com/twpayne/go-geom/pull/159#issuecomment-631264335 instead.