### PR TITLE
fix MultiPolygon and MultiLineString to handle EMPTY sub-geometries

### DIFF
--- a/flat.go
+++ b/flat.go
@@ -290,7 +290,9 @@ func deflate1(flatCoords []float64, coords1 []Coord, stride int) ([]float64, err
 	return flatCoords, nil
 }
 
-func deflate2(flatCoords []float64, ends []int, coords2 [][]Coord, stride int) ([]float64, []int, error) {
+func deflate2(
+	flatCoords []float64, ends []int, coords2 [][]Coord, stride int,
+) ([]float64, []int, error) {
 	for _, coords1 := range coords2 {
 		var err error
 		flatCoords, err = deflate1(flatCoords, coords1, stride)
@@ -302,7 +304,9 @@ func deflate2(flatCoords []float64, ends []int, coords2 [][]Coord, stride int) (
 	return flatCoords, ends, nil
 }
 
-func deflate3(flatCoords []float64, endss [][]int, coords3 [][][]Coord, stride int) ([]float64, [][]int, error) {
+func deflate3(
+	flatCoords []float64, endss [][]int, coords3 [][][]Coord, stride int,
+) ([]float64, [][]int, error) {
 	for _, coords2 := range coords3 {
 		var err error
 		var ends []int
@@ -348,7 +352,9 @@ func inflate3(flatCoords []float64, offset int, endss [][]int, stride int) [][][
 	for i := range coords3 {
 		ends := endss[i]
 		coords3[i] = inflate2(flatCoords, offset, ends, stride)
-		offset = ends[len(ends)-1]
+		if len(ends) > 0 {
+			offset = ends[len(ends)-1]
+		}
 	}
 	return coords3
 }

--- a/multilinestring.go
+++ b/multilinestring.go
@@ -41,6 +41,9 @@ func (g *MultiLineString) LineString(i int) *LineString {
 	if i > 0 {
 		offset = g.ends[i-1]
 	}
+	if offset == g.ends[i] {
+		return NewLineString(g.layout)
+	}
 	return NewLineStringFlat(g.layout, g.flatCoords[offset:g.ends[i]])
 }
 

--- a/multilinestring_test.go
+++ b/multilinestring_test.go
@@ -14,6 +14,7 @@ type testMultiLineString struct {
 	coords     [][]Coord
 	flatCoords []float64
 	ends       []int
+	empty      bool
 	bounds     *Bounds
 }
 
@@ -28,16 +29,19 @@ func testMultiLineStringEquals(t *testing.T, mls *MultiLineString, tmls *testMul
 		t.Errorf("mls.Stride() == %v, want %v", mls.Stride(), tmls.stride)
 	}
 	if !reflect.DeepEqual(mls.Coords(), tmls.coords) {
-		t.Errorf("mls.Coords() == %v, want %v", mls.Coords(), tmls.coords)
+		t.Errorf("mls.Coords() == %#v, want %#v", mls.Coords(), tmls.coords)
 	}
 	if !reflect.DeepEqual(mls.FlatCoords(), tmls.flatCoords) {
-		t.Errorf("mls.FlatCoords() == %v, want %v", mls.FlatCoords(), tmls.flatCoords)
+		t.Errorf("mls.FlatCoords() == %#v, want %#v", mls.FlatCoords(), tmls.flatCoords)
 	}
 	if !reflect.DeepEqual(mls.Ends(), tmls.ends) {
-		t.Errorf("mls.Ends() == %v, want %v", mls.Ends(), tmls.ends)
+		t.Errorf("mls.Ends() == %#v, want %#v", mls.Ends(), tmls.ends)
 	}
 	if !reflect.DeepEqual(mls.Bounds(), tmls.bounds) {
 		t.Errorf("mls.Bounds() == %v, want %v", mls.Bounds(), tmls.bounds)
+	}
+	if mls.Empty() != tmls.empty {
+		t.Errorf("mls.Empty() == %t, want %t", mls.Empty(), tmls.empty)
 	}
 	if got := mls.NumLineStrings(); got != len(tmls.coords) {
 		t.Errorf("mls.NumLineStrings() == %v, want %v", got, len(tmls.coords))
@@ -64,6 +68,43 @@ func TestMultiLineString(t *testing.T) {
 				flatCoords: []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
 				ends:       []int{6, 12},
 				bounds:     NewBounds(XY).Set(1, 2, 11, 12),
+				empty:      false,
+			},
+		},
+		{
+			mls: NewMultiLineString(XY),
+			tmls: &testMultiLineString{
+				layout:     XY,
+				stride:     2,
+				coords:     [][]Coord{},
+				flatCoords: nil,
+				ends:       nil,
+				bounds:     NewBounds(XY),
+				empty:      true,
+			},
+		},
+		{
+			mls: NewMultiLineString(XY).MustSetCoords([][]Coord{{}, {}}),
+			tmls: &testMultiLineString{
+				layout:     XY,
+				stride:     2,
+				coords:     [][]Coord{{}, {}},
+				flatCoords: nil,
+				ends:       []int{0, 0},
+				bounds:     NewBounds(XY),
+				empty:      true,
+			},
+		},
+		{
+			mls: NewMultiLineString(XY).MustSetCoords([][]Coord{{}, {}, {{1, 2}, {3, 4}, {5, 6}}, {{7, 8}, {9, 10}, {11, 12}}, {}}),
+			tmls: &testMultiLineString{
+				layout:     XY,
+				stride:     2,
+				coords:     [][]Coord{{}, {}, {{1, 2}, {3, 4}, {5, 6}}, {{7, 8}, {9, 10}, {11, 12}}, {}},
+				flatCoords: []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
+				ends:       []int{0, 0, 6, 12, 12},
+				bounds:     NewBounds(XY).Set(1, 2, 11, 12),
+				empty:      false,
 			},
 		},
 	} {

--- a/multipolygon.go
+++ b/multipolygon.go
@@ -51,7 +51,12 @@ func (g *MultiPolygon) Polygon(i int) *Polygon {
 	offset := 0
 	if i > 0 {
 		ends := g.endss[i-1]
-		offset = ends[len(ends)-1]
+		if len(ends) > 0 {
+			offset = ends[len(ends)-1]
+		}
+	}
+	if len(g.endss[i]) == 0 {
+		return NewPolygon(g.layout)
 	}
 	ends := make([]int, len(g.endss[i]))
 	if offset == 0 {

--- a/multipolygon_test.go
+++ b/multipolygon_test.go
@@ -15,6 +15,7 @@ type testMultiPolygon struct {
 	flatCoords []float64
 	endss      [][]int
 	bounds     *Bounds
+	empty      bool
 }
 
 func testMultiPolygonEquals(t *testing.T, mp *MultiPolygon, tmp *testMultiPolygon) {
@@ -38,6 +39,9 @@ func testMultiPolygonEquals(t *testing.T, mp *MultiPolygon, tmp *testMultiPolygo
 	}
 	if !reflect.DeepEqual(mp.Bounds(), tmp.bounds) {
 		t.Errorf("mp.Bounds() == %v, want %v", mp.Bounds(), tmp.bounds)
+	}
+	if mp.Empty() != tmp.empty {
+		t.Errorf("mp.Empty() == %t, want %t", mp.Empty(), tmp.empty)
 	}
 	if got := mp.NumPolygons(); got != len(tmp.coords) {
 		t.Errorf("mp.NumPolygons() == %v, want %v", got, len(tmp.coords))
@@ -64,6 +68,43 @@ func TestMultiPolygon(t *testing.T) {
 				flatCoords: []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
 				endss:      [][]int{{6, 12}},
 				bounds:     NewBounds(XY).Set(1, 2, 11, 12),
+				empty:      false,
+			},
+		},
+		{
+			mp: NewMultiPolygon(XY),
+			tmp: &testMultiPolygon{
+				layout:     XY,
+				stride:     2,
+				coords:     [][][]Coord{},
+				flatCoords: nil,
+				endss:      nil,
+				bounds:     NewBounds(XY),
+				empty:      true,
+			},
+		},
+		{
+			mp: NewMultiPolygon(XY).MustSetCoords([][][]Coord{{}, {}}),
+			tmp: &testMultiPolygon{
+				layout:     XY,
+				stride:     2,
+				coords:     [][][]Coord{{}, {}},
+				flatCoords: nil,
+				endss:      [][]int{nil, nil},
+				bounds:     NewBounds(XY),
+				empty:      true,
+			},
+		},
+		{
+			mp: NewMultiPolygon(XY).MustSetCoords([][][]Coord{{}, {}, {{{1, 2}, {3, 4}, {5, 6}}, {{7, 8}, {9, 10}, {11, 12}}}, {}}),
+			tmp: &testMultiPolygon{
+				layout:     XY,
+				stride:     2,
+				coords:     [][][]Coord{{}, {}, {{{1, 2}, {3, 4}, {5, 6}}, {{7, 8}, {9, 10}, {11, 12}}}, {}},
+				flatCoords: []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
+				endss:      [][]int{nil, nil, {6, 12}, nil},
+				bounds:     NewBounds(XY).Set(1, 2, 11, 12),
+				empty:      false,
 			},
 		},
 	} {


### PR DESCRIPTION
MultiLineString / MultiPolygon should be to handle extreme cases such as
MULTILINESTRING (EMPTY, EMPTY) or MULTIPOLYGON (EMPTY, POLYGON(1.0...)).
This PR adapts the code to make this happen. This is compliant with the `ST_IsEmpty` definition.

----

Unfortunately, it will not work for MultiPoint. I'm guessing this is the
reason the spec has:

```
If the geometry is a Point, it SHALL be encoded with each coordinate value set to an IEEE-754 quiet NaN value. GeoPackages SHALL use big endian 0x7ff8000000000000 or little endian 0x000000000000f87f as the binary encoding of the NaN values. (This is because Well-Known Binary as defined in OGC 06-103r4 [9] does not provide a standardized encoding for an empty point set, i.e., 'Point Empty' in Well-Known Text.)
```

It is impossible to tell between "empty" coordinates in MultiPoint if we
store it as an array of coordinates.

~This may render #159 incorrect -- we should instead handle empty coordinates as (NaN, NaN).~ -- see #161 for MULTIPOINT.