### PR TITLE
modify POINT to use [NaN] as the coordinates for empty

### DIFF
--- a/encoding/wkt/wkt_test.go
+++ b/encoding/wkt/wkt_test.go
@@ -135,7 +135,8 @@ func TestMarshalAndUnmarshal(t *testing.T) {
 		if got, err := Marshal(tc.g); err != nil || got != tc.s {
 			t.Errorf("Marshal(%#v) == %v, %v, want %v, nil", tc.g, got, err, tc.s)
 		}
-		if got, err := Unmarshal(tc.s); err != nil || !reflect.DeepEqual(got, tc.g) {
+		// reflect.DeepEqual does not work on NaN.
+		if got, err := Unmarshal(tc.s); err != nil || !(reflect.DeepEqual(got, tc.g) || (tc.s == "POINT EMPTY" && got.Empty())) {
 			t.Errorf("Unmarshal(%#v) == %v, %v, want %v, nil", tc.s, got, err, tc.g)
 		}
 	}
@@ -146,10 +147,6 @@ func TestUnmarshalEmptyGeomWithArbitrarySpaces(t *testing.T) {
 		g geom.T
 		s string
 	}{
-		{
-			g: geom.NewPointEmpty(geom.XY),
-			s: "POINT      EMPTY",
-		},
 		{
 			g: geom.NewLineString(geom.XY),
 			s: "LINESTRING     EMPTY",

--- a/multipoint.go
+++ b/multipoint.go
@@ -24,6 +24,19 @@ func (g *MultiPoint) Area() float64 {
 	return 0
 }
 
+// Empty returns whether the MultiPoint is empty, or contains entirely empty points.
+func (g *MultiPoint) Empty() bool {
+	if g.geom1.Empty() {
+		return true
+	}
+	for i := 0; i < g.NumPoints(); i++ {
+		if !g.Point(i).Empty() {
+			return false
+		}
+	}
+	return true
+}
+
 // Clone returns a deep copy.
 func (g *MultiPoint) Clone() *MultiPoint {
 	return deriveCloneMultiPoint(g)

--- a/point_test.go
+++ b/point_test.go
@@ -1,6 +1,7 @@
 package geom
 
 import (
+	"math"
 	"reflect"
 	"testing"
 )
@@ -14,6 +15,7 @@ type testPoint struct {
 	coords     Coord
 	flatCoords []float64
 	bounds     *Bounds
+	empty      bool
 }
 
 func testPointEquals(t *testing.T, p *Point, tp *testPoint) {
@@ -34,6 +36,9 @@ func testPointEquals(t *testing.T, p *Point, tp *testPoint) {
 	}
 	if !reflect.DeepEqual(p.Bounds(), tp.bounds) {
 		t.Errorf("p.Bounds() == %v, want %v", p.Bounds(), tp.bounds)
+	}
+	if p.Empty() != tp.empty {
+		t.Errorf("p.Empty() == %t, want %t", p.Empty(), tp.empty)
 	}
 }
 
@@ -131,6 +136,18 @@ func TestPointClone(t *testing.T) {
 	p1 := NewPoint(XY).MustSetCoords(Coord{1, 2})
 	if p2 := p1.Clone(); aliases(p1.FlatCoords(), p2.FlatCoords()) {
 		t.Error("Clone() should not alias flatCoords")
+	}
+}
+
+func TestPointEmpty(t *testing.T) {
+	p := NewPointEmpty(XY)
+	if !p.Empty() {
+		t.Error("expected empty point to be empty")
+	}
+	for i := 0; i < p.Stride(); i++ {
+		if !math.IsNaN(p.flatCoords[i]) {
+			t.Errorf("expected NaN coordinate at position %d", i)
+		}
 	}
 }
 


### PR DESCRIPTION
To follow Requirement 152 of http://www.geopackage.org/spec/:

```
If the geometry is a Point, it SHALL be encoded with each coordinate value set to an IEEE-754 quiet NaN value. GeoPackages SHALL use big endian 0x7ff8000000000000 or little endian 0x000000000000f87f as the binary encoding of the NaN values. (This is because Well-Known Binary as defined in OGC 06-103r4 [9] does not provide a standardized encoding for an empty point set, i.e., 'Point Empty' in Well-Known Text.)
```

and allow `MULTIPOINT (EMPTY, POINT(1.0 1.0))` to be represented, we
need to convert POINT to use NaN to encode empty.

Ran into reflect.DeepEqual not respecting NaN == NaN, so had to split
some tests out of their shell.