### PR TITLE
encoding/*wkb: fix panic on invalid layout on empty geometries

### DIFF
--- a/encoding/ewkb/ewkb.go
+++ b/encoding/ewkb/ewkb.go
@@ -226,7 +226,7 @@ func Write(w io.Writer, byteOrder binary.ByteOrder, g geom.T) error {
 	switch g.Layout() {
 	case geom.NoLayout:
 		// Special case for empty GeometryCollections
-		if g, ok := g.(*geom.GeometryCollection); !ok || !g.Empty() {
+		if _, ok := g.(*geom.GeometryCollection); !ok || !g.Empty() {
 			return geom.ErrUnsupportedLayout(g.Layout())
 		}
 	case geom.XY:

--- a/encoding/wkb/wkb.go
+++ b/encoding/wkb/wkb.go
@@ -215,7 +215,7 @@ func Write(w io.Writer, byteOrder binary.ByteOrder, g geom.T) error {
 	switch g.Layout() {
 	case geom.NoLayout:
 		// Special case for empty GeometryCollections
-		if g, ok := g.(*geom.GeometryCollection); !ok || !g.Empty() {
+		if _, ok := g.(*geom.GeometryCollection); !ok || !g.Empty() {
 			return geom.ErrUnsupportedLayout(g.Layout())
 		}
 	case geom.XY:


### PR DESCRIPTION
Previously, if you had `geom.NewPointFlat(geom.NoLayout)`, and tried to
cast it to a WKB or EWKB, a panic would occur instead of invalid layout for
non-GeometryCollections.

This is because the `g` argument would become `nil` and hence
`g.Layout()` would be a nil dereference. Fix that up by not reassigning
`g` (as Empty() is now part of the interface so we don't need it
dereferenced).

(this was my bad :P)