### PR TITLE
encoding/wkt: support maxDecimalDigits

### DIFF
--- a/encoding/wkt/wkt.go
+++ b/encoding/wkt/wkt.go
@@ -26,7 +26,13 @@ var ErrBraceMismatch = errors.New("wkt: brace mismatch")
 
 // Marshal translates a geometry to the corresponding WKT.
 func Marshal(g geom.T) (string, error) {
-	return encode(g)
+	return encode(g, defaultMaxDecimalDigits)
+}
+
+// Marshal translates a geometry to the corresponding WKT.
+// This variant only prints up to the maximum decimal digits for each coord.
+func MarshalWithMaxDecimalDigits(g geom.T, maxDecimalDigits int) (string, error) {
+	return encode(g, maxDecimalDigits)
 }
 
 // Unmarshal translates a WKT to the corresponding geometry.

--- a/encoding/wkt/wkt_test.go
+++ b/encoding/wkt/wkt_test.go
@@ -1,6 +1,7 @@
 package wkt
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -138,6 +139,46 @@ func TestMarshalAndUnmarshal(t *testing.T) {
 		if got, err := Unmarshal(tc.s); err != nil || !reflect.DeepEqual(got, tc.g) {
 			t.Errorf("Unmarshal(%#v) == %v, %v, want %v, nil", tc.s, got, err, tc.g)
 		}
+	}
+}
+
+func TestMarshalWithMaxDecimalDigits(t *testing.T) {
+	for _, tc := range []struct {
+		g                geom.T
+		maxDecimalDigits int
+		s                string
+	}{
+		{
+			g:                geom.NewPointFlat(geom.XY, []float64{1.001, 1.066}),
+			maxDecimalDigits: 0,
+			s:                "POINT (1 1)",
+		},
+		{
+			g:                geom.NewPointFlat(geom.XY, []float64{1.001, 1.066}),
+			maxDecimalDigits: 1,
+			s:                "POINT (1 1.1)",
+		},
+		{
+			g:                geom.NewPointFlat(geom.XY, []float64{1.001, 1.066}),
+			maxDecimalDigits: 2,
+			s:                "POINT (1 1.07)",
+		},
+		{
+			g:                geom.NewPointFlat(geom.XY, []float64{1.001, 1.066}),
+			maxDecimalDigits: 3,
+			s:                "POINT (1.001 1.066)",
+		},
+		{
+			g:                geom.NewPointFlat(geom.XY, []float64{1.001, 1.066}),
+			maxDecimalDigits: 4,
+			s:                "POINT (1.001 1.066)",
+		},
+	} {
+		t.Run(fmt.Sprintf("%s(maxDecimalDigits=%d)", tc.s, tc.maxDecimalDigits), func(t *testing.T) {
+			if got, err := MarshalWithMaxDecimalDigits(tc.g, tc.maxDecimalDigits); err != nil || got != tc.s {
+				t.Errorf("Marshal(%#v) == %v, %v, want %v, nil", tc.g, got, err, tc.s)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
This commit adds support for maximum decimal digits in WKT encoding,
similar to the way PostGIS handles `ST_AsText(<geom>, <maxdecimaldigits>)`.
We have to do extra processing to remove trailing `0` and `.` marks.

I'm not sure if you really want this in the go-geom library, I'm happy to fork it
and have a custom replacement that's more aligned with what we need.
I just didn't want to copy paste most of the code.