### PR TITLE
encoding/wkt: expose maxDecimalDigits as an option

### DIFF
--- a/encoding/wkt/wkt.go
+++ b/encoding/wkt/wkt.go
@@ -24,9 +24,35 @@ const (
 // ErrBraceMismatch is returned when braces do not match.
 var ErrBraceMismatch = errors.New("wkt: brace mismatch")
 
+// Encoder encodes WKT based on specified parameters.
+type Encoder struct {
+	maxDecimalDigits int
+}
+
+// NewEncoder returns a new encoder with the given options set.
+func NewEncoder(applyOptFns ...EncodeOption) *Encoder {
+	encoder := &Encoder{
+		maxDecimalDigits: -1,
+	}
+	for _, applyOptFn := range applyOptFns {
+		applyOptFn(encoder)
+	}
+	return encoder
+}
+
+// EncodeOptions specify options to apply to the encoder.
+type EncodeOption func(*Encoder)
+
+// EncodeWithMaxDecimalDigits sets the maximum decimal digits to encode.
+func EncodeOptionWithMaxDecimalDigits(maxDecimalDigits int) EncodeOption {
+	return func(e *Encoder) {
+		e.maxDecimalDigits = maxDecimalDigits
+	}
+}
+
 // Marshal translates a geometry to the corresponding WKT.
-func Marshal(g geom.T) (string, error) {
-	return encode(g)
+func Marshal(g geom.T, applyOptFns ...EncodeOption) (string, error) {
+	return NewEncoder(applyOptFns...).Encode(g)
 }
 
 // Unmarshal translates a WKT to the corresponding geometry.

--- a/encoding/wkt/wkt_test.go
+++ b/encoding/wkt/wkt_test.go
@@ -1,6 +1,7 @@
 package wkt
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -138,6 +139,46 @@ func TestMarshalAndUnmarshal(t *testing.T) {
 		if got, err := Unmarshal(tc.s); err != nil || !reflect.DeepEqual(got, tc.g) {
 			t.Errorf("Unmarshal(%#v) == %v, %v, want %v, nil", tc.s, got, err, tc.g)
 		}
+	}
+}
+
+func TestEncoder(t *testing.T) {
+	for _, tc := range []struct {
+		encoder *Encoder
+		g       geom.T
+		s       string
+	}{
+		{
+			encoder: NewEncoder(EncodeOptionWithMaxDecimalDigits(0)),
+			g:       geom.NewPointFlat(geom.XY, []float64{1.001, 1.066}),
+			s:       "POINT (1 1)",
+		},
+		{
+			encoder: NewEncoder(EncodeOptionWithMaxDecimalDigits(1)),
+			g:       geom.NewPointFlat(geom.XY, []float64{1.001, 1.066}),
+			s:       "POINT (1 1.1)",
+		},
+		{
+			encoder: NewEncoder(EncodeOptionWithMaxDecimalDigits(2)),
+			g:       geom.NewPointFlat(geom.XY, []float64{1.001, 1.066}),
+			s:       "POINT (1 1.07)",
+		},
+		{
+			encoder: NewEncoder(EncodeOptionWithMaxDecimalDigits(3)),
+			g:       geom.NewPointFlat(geom.XY, []float64{1.001, 1.066}),
+			s:       "POINT (1.001 1.066)",
+		},
+		{
+			encoder: NewEncoder(EncodeOptionWithMaxDecimalDigits(4)),
+			g:       geom.NewPointFlat(geom.XY, []float64{1.001, 1.066}),
+			s:       "POINT (1.001 1.066)",
+		},
+	} {
+		t.Run(fmt.Sprintf("%s(encoder=%#v)", tc.s, tc.encoder), func(t *testing.T) {
+			if got, err := tc.encoder.Encode(tc.g); err != nil || got != tc.s {
+				t.Errorf("Marshal(%#v) == %v, %v, want %v, nil", tc.g, got, err, tc.s)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
This commit adds support for maximum decimal digits in WKT encoding,
similar to the way PostGIS handles ST_AsText(<geom>, <maxdecimaldigits>).
We have to do extra processing to remove trailing 0 and . marks.

To make this change, we also expose "Encoder" as a struct, with the
Encode object made public. This can take in `EncodeOption`s which allow
an arbitrary amount of options in a clean way.