### PR TITLE
encoding: fix maxDecimalDigits truncation

### DIFF
--- a/encoding/geojson/geojson.go
+++ b/encoding/geojson/geojson.go
@@ -253,6 +253,9 @@ func (c *nestedFloat64WithMaxDecimalDigits) marshalJSON(
 		buf = append(buf, ']')
 	case reflect.Float64:
 		buf = strconv.AppendFloat(buf, val.Interface().(float64), 'f', c.maxDecimalDigits, 64)
+		if c.maxDecimalDigits > 0 {
+			buf = bytes.TrimRight(bytes.TrimRight(buf, "0"), ".")
+		}
 	default:
 		return nil, fmt.Errorf("unknown type of coord: %T", val)
 	}

--- a/encoding/geojson/geojson_test.go
+++ b/encoding/geojson/geojson_test.go
@@ -108,9 +108,9 @@ func TestGeometry(t *testing.T) {
 			s: `{"type":"Point","coordinates":[1,2,3,4]}`,
 		},
 		{
-			g:             geom.NewPoint(geom.XYZM).MustSetCoords(geom.Coord{1.451, 2.89, 3.14, 4.23}),
+			g:             geom.NewPoint(geom.XYZM).MustSetCoords(geom.Coord{1.451, 2.89, 3.14, 4.03}),
 			opts:          []EncodeGeometryOption{EncodeGeometryWithMaxDecimalDigits(1)},
-			s:             `{"type":"Point","coordinates":[1.5,2.9,3.1,4.2]}`,
+			s:             `{"type":"Point","coordinates":[1.5,2.9,3.1,4]}`,
 			skipUnmarshal: true,
 		},
 		{
@@ -125,7 +125,7 @@ func TestGeometry(t *testing.T) {
 		{
 			g:             geom.NewLineString(geom.XY).MustSetCoords([]geom.Coord{{1.1234, 2.5678}, {3.1234, 4.01234}}),
 			opts:          []EncodeGeometryOption{EncodeGeometryWithMaxDecimalDigits(1)},
-			s:             `{"type":"LineString","coordinates":[[1.1,2.6],[3.1,4.0]]}`,
+			s:             `{"type":"LineString","coordinates":[[1.1,2.6],[3.1,4]]}`,
 			skipUnmarshal: true,
 		},
 		{
@@ -207,7 +207,7 @@ func TestGeometry(t *testing.T) {
 				geom.NewLineString(geom.XY).MustSetCoords([]geom.Coord{{101.569, 0.898}, {102.123, 1.567}}),
 			),
 			opts:          []EncodeGeometryOption{EncodeGeometryWithMaxDecimalDigits(2)},
-			s:             `{"type":"GeometryCollection","geometries":[{"type":"Point","coordinates":[100.12,0.46]},{"type":"LineString","coordinates":[[101.57,0.90],[102.12,1.57]]}]}`,
+			s:             `{"type":"GeometryCollection","geometries":[{"type":"Point","coordinates":[100.12,0.46]},{"type":"LineString","coordinates":[[101.57,0.9],[102.12,1.57]]}]}`,
 			skipUnmarshal: true,
 		},
 		{
@@ -216,7 +216,7 @@ func TestGeometry(t *testing.T) {
 				geom.NewLineString(geom.XY).MustSetCoords([]geom.Coord{{101.569, 0.898}, {102.123, 1.567}}),
 			),
 			opts:          []EncodeGeometryOption{EncodeGeometryWithMaxDecimalDigits(2), EncodeGeometryWithBBox()},
-			s:             `{"type":"GeometryCollection","bbox":[100.12,0.46,102.12,1.57],"geometries":[{"type":"Point","coordinates":[100.12,0.46]},{"type":"LineString","coordinates":[[101.57,0.90],[102.12,1.57]]}]}`,
+			s:             `{"type":"GeometryCollection","bbox":[100.12,0.46,102.12,1.57],"geometries":[{"type":"Point","coordinates":[100.12,0.46]},{"type":"LineString","coordinates":[[101.57,0.9],[102.12,1.57]]}]}`,
 			skipUnmarshal: true,
 		},
 	} {

--- a/encoding/wkt/encode.go
+++ b/encoding/wkt/encode.go
@@ -123,7 +123,7 @@ func (e *Encoder) writeCoord(sb *strings.Builder, coord []float64) error {
 			}
 		}
 		coordStr := strconv.FormatFloat(x, 'f', e.maxDecimalDigits, 64)
-		if e.maxDecimalDigits != -1 {
+		if e.maxDecimalDigits > 0 {
 			coordStr = strings.TrimRight(strings.TrimRight(coordStr, "0"), ".")
 		}
 		if _, err := sb.WriteString(coordStr); err != nil {

--- a/encoding/wkt/wkt_test.go
+++ b/encoding/wkt/wkt_test.go
@@ -154,6 +154,16 @@ func TestEncoder(t *testing.T) {
 			s:       "POINT (1 1)",
 		},
 		{
+			encoder: NewEncoder(EncodeOptionWithMaxDecimalDigits(0)),
+			g:       geom.NewPointFlat(geom.XY, []float64{10.001, 100.066}),
+			s:       "POINT (10 100)",
+		},
+		{
+			encoder: NewEncoder(EncodeOptionWithMaxDecimalDigits(1)),
+			g:       geom.NewPointFlat(geom.XY, []float64{10.001, 1.066}),
+			s:       "POINT (10 1.1)",
+		},
+		{
 			encoder: NewEncoder(EncodeOptionWithMaxDecimalDigits(1)),
 			g:       geom.NewPointFlat(geom.XY, []float64{1.001, 1.066}),
 			s:       "POINT (1 1.1)",


### PR DESCRIPTION
My bad - found these whilst integrating with a few things.

* For GeoJSON, we didn't truncate the trailing 0's and `.`.
* For WKT, we incorrectly pruned trailing 0's for maxDecimalDigits = 0,
  so items like "10" become "1".