### PR TITLE
encoding/*wkb: handle EMPTY POINT NaN encoding

### DIFF
--- a/encoding/ewkb/ewkb.go
+++ b/encoding/ewkb/ewkb.go
@@ -78,7 +78,7 @@ func Read(r io.Reader) (geom.T, error) {
 		if err != nil {
 			return nil, err
 		}
-		return geom.NewPointFlat(layout, flatCoords).SetSRID(int(srid)), nil
+		return geom.NewPointFlatMaybeEmpty(layout, flatCoords).SetSRID(int(srid)), nil
 	case wkbcommon.LineStringID:
 		flatCoords, err := wkbcommon.ReadFlatCoords1(r, byteOrder, layout.Stride())
 		if err != nil {
@@ -254,6 +254,9 @@ func Write(w io.Writer, byteOrder binary.ByteOrder, g geom.T) error {
 
 	switch g := g.(type) {
 	case *geom.Point:
+		if g.Empty() {
+			return wkbcommon.WriteEmptyPointAsNaN(w, byteOrder, g.Stride())
+		}
 		return wkbcommon.WriteFlatCoords0(w, byteOrder, g.FlatCoords())
 	case *geom.LineString:
 		return wkbcommon.WriteFlatCoords1(w, byteOrder, g.FlatCoords(), g.Stride())

--- a/encoding/ewkb/ewkb_test.go
+++ b/encoding/ewkb/ewkb_test.go
@@ -170,6 +170,36 @@ func Test(t *testing.T) {
 		ndr []byte
 	}{
 		{
+			g:   geom.NewPointEmpty(geom.XY),
+			xdr: mustDecodeString("00000000017ff80000000000007ff8000000000000"),
+			ndr: mustDecodeString("0101000000000000000000f87f000000000000f87f"),
+		},
+		{
+			g:   geom.NewPointEmpty(geom.XYM),
+			xdr: mustDecodeString("00400000017ff80000000000007ff80000000000007ff8000000000000"),
+			ndr: mustDecodeString("0101000040000000000000f87f000000000000f87f000000000000f87f"),
+		},
+		{
+			g:   geom.NewPointEmpty(geom.XYZ),
+			xdr: mustDecodeString("00800000017ff80000000000007ff80000000000007ff8000000000000"),
+			ndr: mustDecodeString("0101000080000000000000f87f000000000000f87f000000000000f87f"),
+		},
+		{
+			g:   geom.NewPointEmpty(geom.XYZM),
+			xdr: mustDecodeString("00c00000017ff80000000000007ff80000000000007ff80000000000007ff8000000000000"),
+			ndr: mustDecodeString("01010000c0000000000000f87f000000000000f87f000000000000f87f000000000000f87f"),
+		},
+		{
+			g:   geom.NewGeometryCollection().MustPush(geom.NewPointEmpty(geom.XY)),
+			xdr: mustDecodeString("00000000070000000100000000017ff80000000000007ff8000000000000"),
+			ndr: mustDecodeString("0107000000010000000101000000000000000000f87f000000000000f87f"),
+		},
+		{
+			g:   geom.NewPointEmpty(geom.XY).SetSRID(4326),
+			xdr: mustDecodeString("0020000001000010e67ff80000000000007ff8000000000000"),
+			ndr: mustDecodeString("0101000020e6100000000000000000f87f000000000000f87f"),
+		},
+		{
 			g:   geom.NewPoint(geom.XY).MustSetCoords(geom.Coord{1, 2}),
 			xdr: mustDecodeString("00000000013ff00000000000004000000000000000"),
 			ndr: mustDecodeString("0101000000000000000000f03f0000000000000040"),

--- a/encoding/wkb/sql.go
+++ b/encoding/wkb/sql.go
@@ -22,42 +22,49 @@ func (e ErrExpectedByteSlice) Error() string {
 // driver.Valuer interfaces.
 type Point struct {
 	*geom.Point
+	opts []wkbcommon.WKBOption
 }
 
 // A LineString is a WKB-encoded LineString that implements the sql.Scanner and
 // driver.Valuer interfaces.
 type LineString struct {
 	*geom.LineString
+	opts []wkbcommon.WKBOption
 }
 
 // A Polygon is a WKB-encoded Polygon that implements the sql.Scanner and
 // driver.Valuer interfaces.
 type Polygon struct {
 	*geom.Polygon
+	opts []wkbcommon.WKBOption
 }
 
 // A MultiPoint is a WKB-encoded MultiPoint that implements the sql.Scanner and
 // driver.Valuer interfaces.
 type MultiPoint struct {
 	*geom.MultiPoint
+	opts []wkbcommon.WKBOption
 }
 
 // A MultiLineString is a WKB-encoded MultiLineString that implements the
 // sql.Scanner and driver.Valuer interfaces.
 type MultiLineString struct {
 	*geom.MultiLineString
+	opts []wkbcommon.WKBOption
 }
 
 // A MultiPolygon is a WKB-encoded MultiPolygon that implements the sql.Scanner
 // and driver.Valuer interfaces.
 type MultiPolygon struct {
 	*geom.MultiPolygon
+	opts []wkbcommon.WKBOption
 }
 
 // A GeometryCollection is a WKB-encoded GeometryCollection that implements the
 // sql.Scanner and driver.Valuer interfaces.
 type GeometryCollection struct {
 	*geom.GeometryCollection
+	opts []wkbcommon.WKBOption
 }
 
 // Scan scans from a []byte.
@@ -66,7 +73,7 @@ func (p *Point) Scan(src interface{}) error {
 	if !ok {
 		return ErrExpectedByteSlice{Value: src}
 	}
-	got, err := Unmarshal(b)
+	got, err := Unmarshal(b, p.opts...)
 	if err != nil {
 		return err
 	}
@@ -89,7 +96,7 @@ func (ls *LineString) Scan(src interface{}) error {
 	if !ok {
 		return ErrExpectedByteSlice{Value: src}
 	}
-	got, err := Unmarshal(b)
+	got, err := Unmarshal(b, ls.opts...)
 	if err != nil {
 		return err
 	}
@@ -112,7 +119,7 @@ func (p *Polygon) Scan(src interface{}) error {
 	if !ok {
 		return ErrExpectedByteSlice{Value: src}
 	}
-	got, err := Unmarshal(b)
+	got, err := Unmarshal(b, p.opts...)
 	if err != nil {
 		return err
 	}
@@ -135,7 +142,7 @@ func (mp *MultiPoint) Scan(src interface{}) error {
 	if !ok {
 		return ErrExpectedByteSlice{Value: src}
 	}
-	got, err := Unmarshal(b)
+	got, err := Unmarshal(b, mp.opts...)
 	if err != nil {
 		return err
 	}
@@ -158,7 +165,7 @@ func (mls *MultiLineString) Scan(src interface{}) error {
 	if !ok {
 		return ErrExpectedByteSlice{Value: src}
 	}
-	got, err := Unmarshal(b)
+	got, err := Unmarshal(b, mls.opts...)
 	if err != nil {
 		return err
 	}
@@ -181,7 +188,7 @@ func (mp *MultiPolygon) Scan(src interface{}) error {
 	if !ok {
 		return ErrExpectedByteSlice{Value: src}
 	}
-	got, err := Unmarshal(b)
+	got, err := Unmarshal(b, mp.opts...)
 	if err != nil {
 		return err
 	}
@@ -204,7 +211,7 @@ func (gc *GeometryCollection) Scan(src interface{}) error {
 	if !ok {
 		return ErrExpectedByteSlice{Value: src}
 	}
-	got, err := Unmarshal(b)
+	got, err := Unmarshal(b, gc.opts...)
 	if err != nil {
 		return err
 	}

--- a/encoding/wkb/wkb.go
+++ b/encoding/wkb/wkb.go
@@ -8,6 +8,7 @@ package wkb
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"io"
 
 	"github.com/twpayne/go-geom"
@@ -29,7 +30,14 @@ const (
 )
 
 // Read reads an arbitrary geometry from r.
-func Read(r io.Reader) (geom.T, error) {
+func Read(r io.Reader, opts ...wkbcommon.WKBOption) (geom.T, error) {
+	params := wkbcommon.InitWKBParams(
+		wkbcommon.WKBParams{
+			EmptyPointHandling: wkbcommon.EmptyPointHandlingError,
+		},
+		opts...,
+	)
+
 	wkbByteOrder, err := wkbcommon.ReadByte(r)
 	if err != nil {
 		return nil, err
@@ -69,6 +77,9 @@ func Read(r io.Reader) (geom.T, error) {
 		flatCoords, err := wkbcommon.ReadFlatCoords0(r, byteOrder, layout.Stride())
 		if err != nil {
 			return nil, err
+		}
+		if params.EmptyPointHandling == wkbcommon.EmptyPointHandlingNaN {
+			return geom.NewPointFlatMaybeEmpty(layout, flatCoords), nil
 		}
 		return geom.NewPointFlat(layout, flatCoords), nil
 	case wkbcommon.LineStringID:
@@ -159,7 +170,7 @@ func Read(r io.Reader) (geom.T, error) {
 		}
 		gc := geom.NewGeometryCollection()
 		for i := uint32(0); i < n; i++ {
-			g, err := Read(r)
+			g, err := Read(r, opts...)
 			if err != nil {
 				return nil, err
 			}
@@ -174,12 +185,19 @@ func Read(r io.Reader) (geom.T, error) {
 }
 
 // Unmarshal unmrshals an arbitrary geometry from a []byte.
-func Unmarshal(data []byte) (geom.T, error) {
-	return Read(bytes.NewBuffer(data))
+func Unmarshal(data []byte, opts ...wkbcommon.WKBOption) (geom.T, error) {
+	return Read(bytes.NewBuffer(data), opts...)
 }
 
 // Write writes an arbitrary geometry to w.
-func Write(w io.Writer, byteOrder binary.ByteOrder, g geom.T) error {
+func Write(w io.Writer, byteOrder binary.ByteOrder, g geom.T, opts ...wkbcommon.WKBOption) error {
+	params := wkbcommon.InitWKBParams(
+		wkbcommon.WKBParams{
+			EmptyPointHandling: wkbcommon.EmptyPointHandlingError,
+		},
+		opts...,
+	)
+
 	var wkbByteOrder byte
 	switch byteOrder {
 	case XDR:
@@ -235,6 +253,16 @@ func Write(w io.Writer, byteOrder binary.ByteOrder, g geom.T) error {
 
 	switch g := g.(type) {
 	case *geom.Point:
+		if g.Empty() {
+			switch params.EmptyPointHandling {
+			case wkbcommon.EmptyPointHandlingNaN:
+				return wkbcommon.WriteEmptyPointAsNaN(w, byteOrder, g.Stride())
+			case wkbcommon.EmptyPointHandlingError:
+				return fmt.Errorf("cannot encode empty WKB")
+			default:
+				return fmt.Errorf("cannot encode empty WKB (unknown option: %d)", wkbcommon.EmptyPointHandlingNaN)
+			}
+		}
 		return wkbcommon.WriteFlatCoords0(w, byteOrder, g.FlatCoords())
 	case *geom.LineString:
 		return wkbcommon.WriteFlatCoords1(w, byteOrder, g.FlatCoords(), g.Stride())
@@ -279,7 +307,7 @@ func Write(w io.Writer, byteOrder binary.ByteOrder, g geom.T) error {
 			return err
 		}
 		for i := 0; i < n; i++ {
-			if err := Write(w, byteOrder, g.Geom(i)); err != nil {
+			if err := Write(w, byteOrder, g.Geom(i), opts...); err != nil {
 				return err
 			}
 		}
@@ -290,9 +318,9 @@ func Write(w io.Writer, byteOrder binary.ByteOrder, g geom.T) error {
 }
 
 // Marshal marshals an arbitrary geometry to a []byte.
-func Marshal(g geom.T, byteOrder binary.ByteOrder) ([]byte, error) {
+func Marshal(g geom.T, byteOrder binary.ByteOrder, opts ...wkbcommon.WKBOption) ([]byte, error) {
 	w := bytes.NewBuffer(nil)
-	if err := Write(w, byteOrder, g); err != nil {
+	if err := Write(w, byteOrder, g, opts...); err != nil {
 		return nil, err
 	}
 	return w.Bytes(), nil

--- a/encoding/wkb/wkb_test.go
+++ b/encoding/wkb/wkb_test.go
@@ -1,6 +1,7 @@
 package wkb
 
 import (
+	"encoding/binary"
 	"encoding/hex"
 	"reflect"
 	"testing"
@@ -11,148 +12,162 @@ import (
 	"github.com/twpayne/go-geom/internal/testdata"
 )
 
-func test(t *testing.T, g geom.T, xdr, ndr []byte) {
+func test(t *testing.T, g geom.T, xdr, ndr []byte, opts ...wkbcommon.WKBOption) {
 	if xdr != nil {
-		if got, err := Unmarshal(xdr); err != nil || !reflect.DeepEqual(got, g) {
+		if got, err := Unmarshal(xdr, opts...); err != nil || !reflect.DeepEqual(got, g) {
 			t.Errorf("Unmarshal(%s) == %#v, %#v, want %#v, nil", hex.EncodeToString(xdr), got, err, g)
 		}
-		if got, err := Marshal(g, XDR); err != nil || !reflect.DeepEqual(got, xdr) {
+		if got, err := Marshal(g, XDR, opts...); err != nil || !reflect.DeepEqual(got, xdr) {
 			t.Errorf("Marshal(%#v, XDR) == %s, %#v, want %s, nil", g, hex.EncodeToString(got), err, hex.EncodeToString(xdr))
 		}
 	}
 	if ndr != nil {
-		if got, err := Unmarshal(ndr); err != nil || !reflect.DeepEqual(got, g) {
+		if got, err := Unmarshal(ndr, opts...); err != nil || !reflect.DeepEqual(got, g) {
 			t.Errorf("Unmarshal(%s) == %#v, %#v, want %#v, nil", hex.EncodeToString(ndr), got, err, g)
 		}
-		if got, err := Marshal(g, NDR); err != nil || !reflect.DeepEqual(got, ndr) {
+		if got, err := Marshal(g, NDR, opts...); err != nil || !reflect.DeepEqual(got, ndr) {
 			t.Errorf("Marshal(%#v, NDR) == %s, %#v, want %#v, nil", g, hex.EncodeToString(got), err, hex.EncodeToString(ndr))
 		}
 	}
 	switch g := g.(type) {
 	case *geom.Point:
-		var p Point
+		p := Point{
+			opts: opts,
+		}
 		if xdr != nil {
 			if err := p.Scan(xdr); err != nil {
 				t.Errorf("%#v.Scan(%#v) == %v, want nil", p, string(xdr), err)
 			}
-			if !reflect.DeepEqual(p, Point{g}) {
-				t.Errorf("Scan(%#v) got %#v, want %#v", string(xdr), p, Point{g})
+			if !reflect.DeepEqual(p, Point{g, opts}) {
+				t.Errorf("Scan(%#v) got %#v, want %#v", string(xdr), p, Point{g, opts})
 			}
 		}
 		if ndr != nil {
 			if err := p.Scan(ndr); err != nil {
 				t.Errorf("%#v.Scan(%#v) == %v, want nil", p, string(ndr), err)
 			}
-			if !reflect.DeepEqual(p, Point{g}) {
-				t.Errorf("Scan(%#v) got %#v, want %#v", string(ndr), p, Point{g})
+			if !reflect.DeepEqual(p, Point{g, opts}) {
+				t.Errorf("Scan(%#v) got %#v, want %#v", string(ndr), p, Point{g, opts})
 			}
 		}
 	case *geom.LineString:
-		var ls LineString
+		ls := LineString{
+			opts: opts,
+		}
 		if xdr != nil {
 			if err := ls.Scan(xdr); err != nil {
 				t.Errorf("%#v.Scan(%#v) == %v, want nil", ls, string(xdr), err)
 			}
-			if !reflect.DeepEqual(ls, LineString{g}) {
-				t.Errorf("Scan(%#v) got %#v, want %#v", string(xdr), ls, LineString{g})
+			if !reflect.DeepEqual(ls, LineString{g, opts}) {
+				t.Errorf("Scan(%#v) got %#v, want %#v", string(xdr), ls, LineString{g, opts})
 			}
 		}
 		if ndr != nil {
 			if err := ls.Scan(ndr); err != nil {
 				t.Errorf("%#v.Scan(%#v) == %v, want nil", ls, string(ndr), err)
 			}
-			if !reflect.DeepEqual(ls, LineString{g}) {
-				t.Errorf("Scan(%#v) got %#v, want %#v", string(ndr), ls, LineString{g})
+			if !reflect.DeepEqual(ls, LineString{g, opts}) {
+				t.Errorf("Scan(%#v) got %#v, want %#v", string(ndr), ls, LineString{g, opts})
 			}
 		}
 	case *geom.Polygon:
-		var p Polygon
+		p := Polygon{
+			opts: opts,
+		}
 		if xdr != nil {
 			if err := p.Scan(xdr); err != nil {
 				t.Errorf("%#v.Scan(%#v) == %v, want nil", p, string(xdr), err)
 			}
-			if !reflect.DeepEqual(p, Polygon{g}) {
-				t.Errorf("Scan(%#v) got %#v, want %#v", string(xdr), p, Polygon{g})
+			if !reflect.DeepEqual(p, Polygon{g, opts}) {
+				t.Errorf("Scan(%#v) got %#v, want %#v", string(xdr), p, Polygon{g, opts})
 			}
 		}
 		if ndr != nil {
 			if err := p.Scan(ndr); err != nil {
 				t.Errorf("%#v.Scan(%#v) == %v, want nil", p, string(ndr), err)
 			}
-			if !reflect.DeepEqual(p, Polygon{g}) {
-				t.Errorf("Scan(%#v) got %#v, want %#v", string(ndr), p, Polygon{g})
+			if !reflect.DeepEqual(p, Polygon{g, opts}) {
+				t.Errorf("Scan(%#v) got %#v, want %#v", string(ndr), p, Polygon{g, opts})
 			}
 		}
 	case *geom.MultiPoint:
-		var mp MultiPoint
+		mp := MultiPoint{
+			opts: opts,
+		}
 		if xdr != nil {
 			if err := mp.Scan(xdr); err != nil {
 				t.Errorf("%#v.Scan(%#v) == %v, want nil", mp, string(xdr), err)
 			}
-			if !reflect.DeepEqual(mp, MultiPoint{g}) {
-				t.Errorf("Scan(%#v) got %#v, want %#v", string(xdr), mp, MultiPoint{g})
+			if !reflect.DeepEqual(mp, MultiPoint{g, opts}) {
+				t.Errorf("Scan(%#v) got %#v, want %#v", string(xdr), mp, MultiPoint{g, opts})
 			}
 		}
 		if ndr != nil {
 			if err := mp.Scan(ndr); err != nil {
 				t.Errorf("%#v.Scan(%#v) == %v, want nil", mp, string(ndr), err)
 			}
-			if !reflect.DeepEqual(mp, MultiPoint{g}) {
-				t.Errorf("Scan(%#v) got %#v, want %#v", string(ndr), mp, MultiPoint{g})
+			if !reflect.DeepEqual(mp, MultiPoint{g, opts}) {
+				t.Errorf("Scan(%#v) got %#v, want %#v", string(ndr), mp, MultiPoint{g, opts})
 			}
 		}
 	case *geom.MultiLineString:
-		var mls MultiLineString
+		mls := MultiLineString{
+			opts: opts,
+		}
 		if xdr != nil {
 			if err := mls.Scan(xdr); err != nil {
 				t.Errorf("%#v.Scan(%#v) == %v, want nil", mls, string(xdr), err)
 			}
-			if !reflect.DeepEqual(mls, MultiLineString{g}) {
-				t.Errorf("Scan(%#v) got %#v, want %#v", string(xdr), mls, MultiLineString{g})
+			if !reflect.DeepEqual(mls, MultiLineString{g, opts}) {
+				t.Errorf("Scan(%#v) got %#v, want %#v", string(xdr), mls, MultiLineString{g, opts})
 			}
 		}
 		if ndr != nil {
 			if err := mls.Scan(ndr); err != nil {
 				t.Errorf("%#v.Scan(%#v) == %v, want nil", mls, string(ndr), err)
 			}
-			if !reflect.DeepEqual(mls, MultiLineString{g}) {
-				t.Errorf("Scan(%#v) got %#v, want %#v", string(ndr), mls, MultiLineString{g})
+			if !reflect.DeepEqual(mls, MultiLineString{g, opts}) {
+				t.Errorf("Scan(%#v) got %#v, want %#v", string(ndr), mls, MultiLineString{g, opts})
 			}
 		}
 	case *geom.MultiPolygon:
-		var mp MultiPolygon
+		mp := MultiPolygon{
+			opts: opts,
+		}
 		if xdr != nil {
 			if err := mp.Scan(xdr); err != nil {
 				t.Errorf("%#v.Scan(%#v) == %v, want nil", mp, string(xdr), err)
 			}
-			if !reflect.DeepEqual(mp, MultiPolygon{g}) {
-				t.Errorf("Scan(%#v) got %#v, want %#v", string(xdr), mp, MultiPolygon{g})
+			if !reflect.DeepEqual(mp, MultiPolygon{g, opts}) {
+				t.Errorf("Scan(%#v) got %#v, want %#v", string(xdr), mp, MultiPolygon{g, opts})
 			}
 		}
 		if ndr != nil {
 			if err := mp.Scan(ndr); err != nil {
 				t.Errorf("%#v.Scan(%#v) == %v, want nil", mp, string(ndr), err)
 			}
-			if !reflect.DeepEqual(mp, MultiPolygon{g}) {
-				t.Errorf("Scan(%#v) got %#v, want %#v", string(ndr), mp, MultiPolygon{g})
+			if !reflect.DeepEqual(mp, MultiPolygon{g, opts}) {
+				t.Errorf("Scan(%#v) got %#v, want %#v", string(ndr), mp, MultiPolygon{g, opts})
 			}
 		}
 	case *geom.GeometryCollection:
-		var gc GeometryCollection
+		gc := GeometryCollection{
+			opts: opts,
+		}
 		if xdr != nil {
 			if err := gc.Scan(xdr); err != nil {
 				t.Errorf("%#v.Scan(%#v) == %v, want nil", gc, string(xdr), err)
 			}
-			if !reflect.DeepEqual(gc, GeometryCollection{g}) {
-				t.Errorf("Scan(%#v) got %#v, want %#v", string(xdr), gc, GeometryCollection{g})
+			if !reflect.DeepEqual(gc, GeometryCollection{g, opts}) {
+				t.Errorf("Scan(%#v) got %#v, want %#v", string(xdr), gc, GeometryCollection{g, opts})
 			}
 		}
 		if ndr != nil {
 			if err := gc.Scan(ndr); err != nil {
 				t.Errorf("%#v.Scan(%#v) == %v, want nil", gc, string(ndr), err)
 			}
-			if !reflect.DeepEqual(gc, GeometryCollection{g}) {
-				t.Errorf("Scan(%#v) got %#v, want %#v", string(ndr), gc, GeometryCollection{g})
+			if !reflect.DeepEqual(gc, GeometryCollection{g, opts}) {
+				t.Errorf("Scan(%#v) got %#v, want %#v", string(ndr), gc, GeometryCollection{g, opts})
 			}
 		}
 	}
@@ -160,10 +175,41 @@ func test(t *testing.T, g geom.T, xdr, ndr []byte) {
 
 func Test(t *testing.T) {
 	for _, tc := range []struct {
-		g   geom.T
-		xdr []byte
-		ndr []byte
+		g    geom.T
+		opts []wkbcommon.WKBOption
+		xdr  []byte
+		ndr  []byte
 	}{
+		{
+			g:    geom.NewPointEmpty(geom.XY),
+			opts: []wkbcommon.WKBOption{wkbcommon.WKBOptionEmptyPointHandling(wkbcommon.EmptyPointHandlingNaN)},
+			xdr:  geomtest.MustHexDecode("00000000017ff80000000000007ff8000000000000"),
+			ndr:  geomtest.MustHexDecode("0101000000000000000000f87f000000000000f87f"),
+		},
+		{
+			g:    geom.NewPointEmpty(geom.XYM),
+			opts: []wkbcommon.WKBOption{wkbcommon.WKBOptionEmptyPointHandling(wkbcommon.EmptyPointHandlingNaN)},
+			xdr:  geomtest.MustHexDecode("00000007d17ff80000000000007ff80000000000007ff8000000000000"),
+			ndr:  geomtest.MustHexDecode("01d1070000000000000000f87f000000000000f87f000000000000f87f"),
+		},
+		{
+			g:    geom.NewPointEmpty(geom.XYZ),
+			opts: []wkbcommon.WKBOption{wkbcommon.WKBOptionEmptyPointHandling(wkbcommon.EmptyPointHandlingNaN)},
+			xdr:  geomtest.MustHexDecode("00000003e97ff80000000000007ff80000000000007ff8000000000000"),
+			ndr:  geomtest.MustHexDecode("01e9030000000000000000f87f000000000000f87f000000000000f87f"),
+		},
+		{
+			g:    geom.NewPointEmpty(geom.XYZM),
+			opts: []wkbcommon.WKBOption{wkbcommon.WKBOptionEmptyPointHandling(wkbcommon.EmptyPointHandlingNaN)},
+			xdr:  geomtest.MustHexDecode("0000000bb97ff80000000000007ff80000000000007ff80000000000007ff8000000000000"),
+			ndr:  geomtest.MustHexDecode("01b90b0000000000000000f87f000000000000f87f000000000000f87f000000000000f87f"),
+		},
+		{
+			g:    geom.NewGeometryCollection().MustPush(geom.NewPointEmpty(geom.XY)),
+			opts: []wkbcommon.WKBOption{wkbcommon.WKBOptionEmptyPointHandling(wkbcommon.EmptyPointHandlingNaN)},
+			xdr:  geomtest.MustHexDecode("00000000070000000100000000017ff80000000000007ff8000000000000"),
+			ndr:  geomtest.MustHexDecode("0107000000010000000101000000000000000000f87f000000000000f87f"),
+		},
 		{
 			g:   geom.NewPoint(geom.XY).MustSetCoords(geom.Coord{1, 2}),
 			xdr: geomtest.MustHexDecode("00000000013ff00000000000004000000000000000"),
@@ -259,8 +305,16 @@ func Test(t *testing.T) {
 			ndr: geomtest.MustHexDecode("0107000000030000000101000000550B36BFABD753C07CE58B07A5D24540010200000005000000C4190D2ABBD753C028AA6D799BD24540B51F84DBB5D753C07954A1269FD24540F9DB9E20B1D753C0E3D011AFA1D24540FB8E86F8ACD753C0ED444948A4D24540550B36BFABD753C07CE58B07A5D24540010200000002000000550B36BFABD753C07CE58B07A5D24540F6D786E5AAD753C0C619C39CA0D24540"),
 		},
 	} {
-		test(t, tc.g, tc.xdr, tc.ndr)
+		test(t, tc.g, tc.xdr, tc.ndr, tc.opts...)
 	}
+
+	t.Run("errors when encoding WKB by default", func(t *testing.T) {
+		_, err := Marshal(geom.NewPointEmpty(geom.XY), binary.LittleEndian)
+		matchStr := "cannot encode empty WKB"
+		if err == nil || err.Error() != matchStr {
+			t.Errorf("expected error matching %s, got %#v", matchStr, err)
+		}
+	})
 }
 
 func TestRandom(t *testing.T) {

--- a/encoding/wkbcommon/binary.go
+++ b/encoding/wkbcommon/binary.go
@@ -5,6 +5,8 @@ import (
 	"encoding/binary"
 	"io"
 	"math"
+
+	"github.com/twpayne/go-geom"
 )
 
 func readFloat(buf []byte, byteOrder binary.ByteOrder) float64 {
@@ -72,4 +74,13 @@ func WriteByte(w io.Writer, value byte) error {
 	buf[0] = value
 	_, err := w.Write(buf[:])
 	return err
+}
+
+// WriteEmptyPointAsNaN outputs EmptyPoint as NaN values.
+func WriteEmptyPointAsNaN(w io.Writer, byteOrder binary.ByteOrder, numCoords int) error {
+	coords := make([]float64, numCoords)
+	for i := 0; i < numCoords; i++ {
+		coords[i] = geom.PointEmptyCoord()
+	}
+	return WriteFlatCoords0(w, byteOrder, coords)
 }

--- a/encoding/wkbcommon/options.go
+++ b/encoding/wkbcommon/options.go
@@ -1,0 +1,36 @@
+package wkbcommon
+
+// EmptyPointHandling is the mechanism to handle an empty point.
+type EmptyPointHandling uint8
+
+const (
+	// EmptyPointHandlingError will error if an empty point is found.
+	EmptyPointHandlingError EmptyPointHandling = iota
+	// EmptyPointHandlingNaN will decipher empty points with NaN as coordinates.
+	// This is in line with Requirement 152 of the GeoPackage spec (http://www.geopackage.org/spec/).
+	EmptyPointHandlingNaN
+)
+
+// WKBParams are parameters for encoding and decoding WKB items.
+type WKBParams struct {
+	EmptyPointHandling EmptyPointHandling
+}
+
+// WKBOption is an option to set on WKBParams.
+type WKBOption func(WKBParams) WKBParams
+
+// WKBOptionEmptyPointHandling sets the params to the specified EmptyPointHandling.
+func WKBOptionEmptyPointHandling(h EmptyPointHandling) WKBOption {
+	return func(p WKBParams) WKBParams {
+		p.EmptyPointHandling = h
+		return p
+	}
+}
+
+// InitWKBParams initializes WKBParams from an initial parameter and some options.
+func InitWKBParams(params WKBParams, opts ...WKBOption) WKBParams {
+	for _, opt := range opts {
+		params = opt(params)
+	}
+	return params
+}

--- a/encoding/wkbhex/wkbhex.go
+++ b/encoding/wkbhex/wkbhex.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/twpayne/go-geom"
 	"github.com/twpayne/go-geom/encoding/wkb"
+	"github.com/twpayne/go-geom/encoding/wkbcommon"
 )
 
 var (
@@ -18,8 +19,8 @@ var (
 )
 
 // Encode encodes an arbitrary geometry to a string.
-func Encode(g geom.T, byteOrder binary.ByteOrder) (string, error) {
-	wkb, err := wkb.Marshal(g, byteOrder)
+func Encode(g geom.T, byteOrder binary.ByteOrder, opts ...wkbcommon.WKBOption) (string, error) {
+	wkb, err := wkb.Marshal(g, byteOrder, opts...)
 	if err != nil {
 		return "", err
 	}
@@ -27,10 +28,10 @@ func Encode(g geom.T, byteOrder binary.ByteOrder) (string, error) {
 }
 
 // Decode decodes an arbitrary geometry from a string.
-func Decode(s string) (geom.T, error) {
+func Decode(s string, opts ...wkbcommon.WKBOption) (geom.T, error) {
 	data, err := hex.DecodeString(s)
 	if err != nil {
 		return nil, err
 	}
-	return wkb.Unmarshal(data)
+	return wkb.Unmarshal(data, opts...)
 }

--- a/encoding/wkbhex/wkbhex_test.go
+++ b/encoding/wkbhex/wkbhex_test.go
@@ -6,14 +6,46 @@ import (
 
 	"github.com/twpayne/go-geom"
 	"github.com/twpayne/go-geom/encoding/wkb"
+	"github.com/twpayne/go-geom/encoding/wkbcommon"
 )
 
 func Test(t *testing.T) {
 	for _, tc := range []struct {
-		g   geom.T
-		ndr string
-		xdr string
+		g    geom.T
+		opts []wkbcommon.WKBOption
+		ndr  string
+		xdr  string
 	}{
+		{
+			g:    geom.NewPointEmpty(geom.XY),
+			opts: []wkbcommon.WKBOption{wkbcommon.WKBOptionEmptyPointHandling(wkbcommon.EmptyPointHandlingNaN)},
+			xdr:  "00000000017ff80000000000007ff8000000000000",
+			ndr:  "0101000000000000000000f87f000000000000f87f",
+		},
+		{
+			g:    geom.NewPointEmpty(geom.XYM),
+			opts: []wkbcommon.WKBOption{wkbcommon.WKBOptionEmptyPointHandling(wkbcommon.EmptyPointHandlingNaN)},
+			xdr:  "00000007d17ff80000000000007ff80000000000007ff8000000000000",
+			ndr:  "01d1070000000000000000f87f000000000000f87f000000000000f87f",
+		},
+		{
+			g:    geom.NewPointEmpty(geom.XYZ),
+			opts: []wkbcommon.WKBOption{wkbcommon.WKBOptionEmptyPointHandling(wkbcommon.EmptyPointHandlingNaN)},
+			xdr:  "00000003e97ff80000000000007ff80000000000007ff8000000000000",
+			ndr:  "01e9030000000000000000f87f000000000000f87f000000000000f87f",
+		},
+		{
+			g:    geom.NewPointEmpty(geom.XYZM),
+			opts: []wkbcommon.WKBOption{wkbcommon.WKBOptionEmptyPointHandling(wkbcommon.EmptyPointHandlingNaN)},
+			xdr:  "0000000bb97ff80000000000007ff80000000000007ff80000000000007ff8000000000000",
+			ndr:  "01b90b0000000000000000f87f000000000000f87f000000000000f87f000000000000f87f",
+		},
+		{
+			g:    geom.NewGeometryCollection().MustPush(geom.NewPointEmpty(geom.XY)),
+			opts: []wkbcommon.WKBOption{wkbcommon.WKBOptionEmptyPointHandling(wkbcommon.EmptyPointHandlingNaN)},
+			xdr:  "00000000070000000100000000017ff80000000000007ff8000000000000",
+			ndr:  "0107000000010000000101000000000000000000f87f000000000000f87f",
+		},
 		{
 			g:   geom.NewPoint(geom.XY).MustSetCoords(geom.Coord{1, 2}),
 			ndr: "0101000000000000000000f03f0000000000000040",
@@ -120,18 +152,18 @@ func Test(t *testing.T) {
 		},
 	} {
 		if tc.ndr != "" {
-			if got, err := Encode(tc.g, wkb.NDR); err != nil || got != tc.ndr {
+			if got, err := Encode(tc.g, wkb.NDR, tc.opts...); err != nil || got != tc.ndr {
 				t.Errorf("Encode(%#v, %#v) == %#v, %#v, want %#v, nil", tc.g, wkb.NDR, got, err, tc.ndr)
 			}
-			if got, err := Decode(tc.ndr); err != nil || !reflect.DeepEqual(got, tc.g) {
+			if got, err := Decode(tc.ndr, tc.opts...); err != nil || !reflect.DeepEqual(got, tc.g) {
 				t.Errorf("Decode(%#v) == %#v, %v, want %#v, nil", tc.ndr, got, err, tc.g)
 			}
 		}
 		if tc.xdr != "" {
-			if got, err := Encode(tc.g, wkb.XDR); err != nil || got != tc.xdr {
+			if got, err := Encode(tc.g, wkb.XDR, tc.opts...); err != nil || got != tc.xdr {
 				t.Errorf("Encode(%#v, %#v) == %#v, %#v, want %#v, nil", tc.g, wkb.XDR, got, err, tc.xdr)
 			}
-			if got, err := Decode(tc.xdr); err != nil || !reflect.DeepEqual(got, tc.g) {
+			if got, err := Decode(tc.xdr, tc.opts...); err != nil || !reflect.DeepEqual(got, tc.g) {
 				t.Errorf("Decode(%#v) == %#v, %v, want %#v, nil", tc.xdr, got, err, tc.g)
 			}
 		}

--- a/point.go
+++ b/point.go
@@ -1,5 +1,16 @@
 package geom
 
+import "math"
+
+// PointEmptyCoordHex is the hex representation of a NaN that represents
+// an empty coord in a shape.
+const PointEmptyCoordHex = 0x7FF8000000000000
+
+// PointEmptyCoord is the NaN float64 representation of the empty coordinate.
+func PointEmptyCoord() float64 {
+	return math.Float64frombits(PointEmptyCoordHex)
+}
+
 // A Point represents a single point.
 type Point struct {
 	geom0
@@ -22,6 +33,22 @@ func NewPointFlat(l Layout, flatCoords []float64) *Point {
 	g.stride = l.Stride()
 	g.flatCoords = flatCoords
 	return g
+}
+
+// NewPointFlatMaybeEmpty returns a new point, checking whether the point may be empty
+// by checking wther all the points are NaN.
+func NewPointFlatMaybeEmpty(layout Layout, flatCoords []float64) *Point {
+	isEmpty := true
+	for _, coord := range flatCoords {
+		if math.Float64bits(coord) != PointEmptyCoordHex {
+			isEmpty = false
+			break
+		}
+	}
+	if isEmpty {
+		return NewPointEmpty(layout)
+	}
+	return NewPointFlat(layout, flatCoords)
 }
 
 // Area returns g's area, i.e. zero.


### PR DESCRIPTION
For EWKB, NaNs will now encode and decode as EMPTY points.

For WKB, we specify an option to encode and decode points as empty with
NaNs. If not set, NaN points will encode as an error, and decode with
coordinates of (NaN, NaN...).

Resolves #164.