### PR TITLE
encoding/geojson: correctly handle POINT EMPTY

### DIFF
--- a/point.go
+++ b/point.go
@@ -23,7 +23,7 @@ func NewPoint(l Layout) *Point {
 
 // NewPointEmpty allocates a new Point with no coordinates.
 func NewPointEmpty(l Layout) *Point {
-	return NewPointFlat(l, []float64{})
+	return NewPointFlat(l, nil)
 }
 
 // NewPointFlat allocates a new Point with layout l and flat coordinates flatCoords.


### PR DESCRIPTION
* For EMPTY points, the EMPTY point should still display with values
  `[]`, analogous to PostGIS.
* For EMPTY GeometryCollections, geometries were omitted but the field
  `geometries` should still be included.

