### PR TITLE
encoding/wkb: new type Geom

### DIFF
--- a/encoding/wkb/sql.go
+++ b/encoding/wkb/sql.go
@@ -23,8 +23,6 @@ func (e ErrExpectedByteSlice) Error() string {
 // It can be used when the geometry shape is not defined.
 type Geom struct {
 	geom.T
-	// NOTE(tb) I've repeated the opts field like other types, but I'm not sure
-	// about its usage.
 	opts []wkbcommon.WKBOption
 }
 
@@ -97,8 +95,7 @@ func (g *Geom) Value() (driver.Value, error) {
 	return value(g.T)
 }
 
-// NOTE(tb) you asked for this method but since accessing the geom.T is trivial
-// as writing g.T, I wonder if it worth it.
+// Geom returns the underlying geom.T
 func (g *Geom) Geom() geom.T {
 	return g.T
 }

--- a/encoding/wkb/sql.go
+++ b/encoding/wkb/sql.go
@@ -18,6 +18,16 @@ func (e ErrExpectedByteSlice) Error() string {
 	return fmt.Sprintf("wkb: want []byte, got %T", e.Value)
 }
 
+// A Geom is a WKB-ecoded Geometry that implements the sql.Scanner and
+// driver.Value interfaces.
+// It can be used when the geometry shape is not defined.
+type Geom struct {
+	geom.T
+	// NOTE(tb) I've repeated the opts field like other types, but I'm not sure
+	// about its usage.
+	opts []wkbcommon.WKBOption
+}
+
 // A Point is a WKB-encoded Point that implements the sql.Scanner and
 // driver.Valuer interfaces.
 type Point struct {
@@ -65,6 +75,32 @@ type MultiPolygon struct {
 type GeometryCollection struct {
 	*geom.GeometryCollection
 	opts []wkbcommon.WKBOption
+}
+
+// Scan scans from a []byte.
+func (g *Geom) Scan(src interface{}) error {
+	b, ok := src.([]byte)
+	if !ok {
+		return ErrExpectedByteSlice{Value: src}
+	}
+	// NOTE(tb) other Scanners do not check the len of b, is it really useful ?
+	if len(b) == 0 {
+		return nil
+	}
+	var err error
+	g.T, err = Unmarshal(b, g.opts...)
+	return err
+}
+
+// Value returns the WKB encoding of g.
+func (g *Geom) Value() (driver.Value, error) {
+	return value(g.T)
+}
+
+// NOTE(tb) you asked for this method but since accessing the geom.T is trivial
+// as writing g.T, I wonder if it worth it.
+func (g *Geom) Geom() geom.T {
+	return g.T
 }
 
 // Scan scans from a []byte.

--- a/encoding/wkb/sql.go
+++ b/encoding/wkb/sql.go
@@ -95,7 +95,7 @@ func (g *Geom) Value() (driver.Value, error) {
 	return value(g.T)
 }
 
-// Geom returns the underlying geom.T
+// Geom returns the underlying geom.T.
 func (g *Geom) Geom() geom.T {
 	return g.T
 }

--- a/encoding/wkb/sql_example_test.go
+++ b/encoding/wkb/sql_example_test.go
@@ -74,3 +74,98 @@ func Example_value() {
 	// Output:
 	// 1 rows affected
 }
+
+func Example_scan_different_shapes() {
+	type Shape struct {
+		Name string
+		Geom wkb.Geom
+	}
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery(`SELECT name, ST_AsBinary\(geom\) FROM shapes`).
+		WillReturnRows(
+			sqlmock.NewRows([]string{"name", "location"}).
+				AddRow("Point", geomtest.MustHexDecode("0101000000000000000000F03F0000000000000040")).
+				AddRow("LineString", geomtest.MustHexDecode("010200000002000000000000000000F03F000000000000004000000000000008400000000000001040")).
+				AddRow("Polygon", geomtest.MustHexDecode("01030000000100000004000000000000000000F03F00000000000000400000000000000840000000000000104000000000000014400000000000001840000000000000F03F0000000000000040")),
+		)
+
+	rows, err := db.Query(`SELECT name, ST_AsBinary(geom) FROM shapes`)
+	if err != nil {
+		log.Fatal(err)
+	}
+	for rows.Next() {
+		var s Shape
+		err := rows.Scan(&s.Name, &s.Geom)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Printf("%s: %v\n", s.Name, s.Geom.FlatCoords())
+	}
+
+	// Output:
+	// Point: [1 2]
+	// LineString: [1 2 3 4]
+	// Polygon: [1 2 3 4 5 6 1 2]
+}
+
+func Example_value_different_shapes() {
+	type Shape struct {
+		Name string
+		Geom wkb.Geom
+	}
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec(`INSERT INTO objects \(name, location\) VALUES \(\?, \?\);`).
+		WithArgs("Point", geomtest.MustHexDecode("0101000000000000000000F03F0000000000000040")).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(`INSERT INTO objects \(name, location\) VALUES \(\?, \?\);`).
+		WithArgs("LineString", geomtest.MustHexDecode("010200000002000000000000000000F03F000000000000004000000000000008400000000000001040")).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(`INSERT INTO objects \(name, location\) VALUES \(\?, \?\);`).
+		WithArgs("Polygon", geomtest.MustHexDecode("01030000000100000004000000000000000000F03F00000000000000400000000000000840000000000000104000000000000014400000000000001840000000000000F03F0000000000000040")).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	shapes := []Shape{
+		{
+			Name: "Point",
+			Geom: wkb.Geom{T: geom.NewPoint(geom.XY).MustSetCoords(geom.Coord{1, 2})},
+		},
+		{
+			Name: "LineString",
+			Geom: wkb.Geom{T: geom.NewLineString(geom.XY).MustSetCoords([]geom.Coord{{1, 2}, {3, 4}})},
+		},
+		{
+			Name: "Polygon",
+			Geom: wkb.Geom{
+				T: geom.NewPolygon(geom.XY).MustSetCoords([][]geom.Coord{
+					{{1, 2}, {3, 4}, {5, 6}, {1, 2}},
+				}),
+			},
+		},
+	}
+
+	for _, s := range shapes {
+		result, err := db.Exec(`INSERT INTO objects (name, location) VALUES (?, ?);`, s.Name, &s.Geom)
+		if err != nil {
+			log.Fatal(err)
+		}
+		rowsAffected, _ := result.RowsAffected()
+		fmt.Printf("%d rows affected\n", rowsAffected)
+	}
+
+	// Output:
+	// 1 rows affected
+	// 1 rows affected
+	// 1 rows affected
+}


### PR DESCRIPTION
When the shape of a geometry isn't defined (for example when you use the
GEOMETRY postgis type), you can't use the scanners defined in
encoding/wkb, you have to iterate over the results and invoke
wkb.Marshal on the column.

This change introduces a new type wkb.Geom which can scan any kind of
geometry shape.

I've added NOTEs about details I would like to discuss, please review
them.

I've also added new examples to illustrate the usage, tell me if the
example names are OK for you.