### PR TITLE
geojson: fix rune cast for Go 1.15

### DIFF
--- a/encoding/geojson/geojson.go
+++ b/encoding/geojson/geojson.go
@@ -535,7 +535,7 @@ func encodeBBox(b *geom.Bounds) ([]float64, error) {
 			b.Max(0), b.Max(1), b.Max(2),
 		}, nil
 	default:
-		return []float64{}, ErrUnsupportedType(l)
+		return []float64{}, ErrUnsupportedType(rune(l))
 	}
 }
 


### PR DESCRIPTION
In Go 1.15, [integers must be explicitly cast to runes](https://golang.org/doc/go1.15#vet) before being cast to strings, to avoid `go vet` errors. These are enabled by default on `go test`, causing test failures.