### PR TITLE
Don't consider coordinates beyond Z when testing for polygon closure

### DIFF
--- a/encoding/wkt/lex.go
+++ b/encoding/wkt/lex.go
@@ -324,7 +324,11 @@ func (l *wktLex) isValidPolygonRing(flatCoords []float64) bool {
 		l.setParseError("polygon ring doesn't have enough points", "minimum number of points is 4")
 		return false
 	}
-	for i := 0; i < stride; i++ {
+	dimensions := 2
+	if l.curLayout().ZIndex() != -1 {
+		dimensions = 3
+	}
+	for i := 0; i < dimensions; i++ {
 		if flatCoords[i] != flatCoords[len(flatCoords)-stride+i] {
 			l.setParseError("polygon ring not closed", "ensure first and last point are the same")
 			return false

--- a/encoding/wkt/wkt_test.go
+++ b/encoding/wkt/wkt_test.go
@@ -71,6 +71,14 @@ func TestMarshalAndUnmarshal(t *testing.T) {
 			s: "POLYGON ((1 2, 3 4, 5 6, 1 2), (7 8, 9 10, 11 12, 7 8))",
 		},
 		{
+			g: geom.NewPolygon(geom.XYM).MustSetCoords([][]geom.Coord{{{0, 0, 0}, {1, 0, 1}, {1, 1, 2}, {0, 0, 3}}}),
+			s: "POLYGON M ((0 0 0, 1 0 1, 1 1 2, 0 0 3))",
+		},
+		{
+			g: geom.NewPolygon(geom.XYZM).MustSetCoords([][]geom.Coord{{{0, 0, 0, 0}, {1, 0, -1, 1}, {1, 1, -2, 2}, {0, 0, 0, 3}}}),
+			s: "POLYGON ZM ((0 0 0 0, 1 0 -1 1, 1 1 -2 2, 0 0 0 3))",
+		},
+		{
 			g: geom.NewMultiPoint(geom.XY),
 			s: "MULTIPOINT EMPTY",
 		},


### PR DESCRIPTION
From PostGIS:

```
postgis=# SELECT ST_IsClosed('POLYGON ZM ((0 0 0 0, 1 0 -1 1, 1 1 -2 2, 0 0 0 3))'::geometry);
 st_isclosed
-------------
 t
(1 row)
```

Note that the polygon is considered closed, even though the M coordinates of the first and last points differ.