### PR TITLE
Fix lint warning in GeoJSON unmarshaling

### DIFF
--- a/encoding/geojson/geojson.go
+++ b/encoding/geojson/geojson.go
@@ -493,18 +493,10 @@ func Marshal(g geom.T, opts ...EncodeGeometryOption) ([]byte, error) {
 
 // Unmarshal unmarshalls a []byte to an arbitrary geometry.
 func Unmarshal(data []byte, g *geom.T) error {
-	if bytes.Equal(data, nullGeometry) {
-		*g = nil
-		return nil
-	}
-	// FIXME The following lint error is suppressed, but there is probably a genuine error here
-	//
-	//nolint:staticcheck
 	gg := &Geometry{}
-	if err := json.Unmarshal(data, gg); err != nil {
+	if err := json.Unmarshal(data, &gg); err != nil {
 		return err
 	}
-	//nolint:staticcheck
 	if gg == nil {
 		*g = nil
 		return nil


### PR DESCRIPTION
A double pointer is needed here to pass through null as nil.

Note that the tests still pass after this change.