### PR TITLE
Reject non-finite coordinates when encoding WKT

### DIFF
--- a/encoding/wkt/encode.go
+++ b/encoding/wkt/encode.go
@@ -1,6 +1,7 @@
 package wkt
 
 import (
+	"math"
 	"strconv"
 	"strings"
 
@@ -117,6 +118,11 @@ func (e *Encoder) write(sb *strings.Builder, g geom.T) error {
 
 func (e *Encoder) writeCoord(sb *strings.Builder, coord []float64) error {
 	for i, x := range coord {
+		// WKT has no token for non-finite ordinates and the decoder rejects
+		// them, so reject rather than emit output we cannot read back.
+		if math.IsNaN(x) || math.IsInf(x, 0) {
+			return ErrNonFiniteCoord{Value: x}
+		}
 		if i != 0 {
 			if _, err := sb.WriteRune(' '); err != nil {
 				return err

--- a/encoding/wkt/encode_nonfinite_test.go
+++ b/encoding/wkt/encode_nonfinite_test.go
@@ -1,0 +1,113 @@
+package wkt
+
+import (
+	"math"
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+
+	"github.com/twpayne/go-geom"
+)
+
+// TestMarshalNonFiniteCoord covers the whole set of geometry types that reach
+// writeCoord. A non-finite ordinate (NaN or ±Inf) has no WKT representation and
+// the decoder rejects the tokens, so Marshal must return an error and emit no
+// string rather than produce output it cannot read back.
+func TestMarshalNonFiniteCoord(t *testing.T) {
+	for _, nonFinite := range []struct {
+		name string
+		v    float64
+	}{
+		{"NaN", math.NaN()},
+		{"+Inf", math.Inf(1)},
+		{"-Inf", math.Inf(-1)},
+	} {
+		bad := nonFinite.v
+		for _, tc := range []struct {
+			name string
+			g    geom.T
+		}{
+			{"Point", geom.NewPointFlat(geom.XY, []float64{bad, 2})},
+			{"PointZ", geom.NewPointFlat(geom.XYZ, []float64{1, 2, bad})},
+			{"PointM", geom.NewPointFlat(geom.XYM, []float64{1, 2, bad})},
+			{"PointZM", geom.NewPointFlat(geom.XYZM, []float64{1, 2, 3, bad})},
+			{"LineString", geom.NewLineStringFlat(geom.XY, []float64{1, 2, bad, 4})},
+			{"LinearRing", geom.NewLinearRingFlat(geom.XY, []float64{0, 0, 1, 0, bad, 1, 0, 0})},
+			{"Polygon", geom.NewPolygonFlat(geom.XY, []float64{0, 0, 1, 0, 1, 1, bad, 0}, []int{8})},
+			{"MultiPoint", geom.NewMultiPointFlat(geom.XY, []float64{1, 2, bad, 4})},
+			{"MultiLineString", geom.NewMultiLineStringFlat(geom.XY, []float64{0, 0, bad, 1}, []int{4})},
+			{"MultiPolygon", geom.NewMultiPolygonFlat(geom.XY, []float64{0, 0, 1, 0, 1, 1, bad, 0}, [][]int{{8}})},
+			{"GeometryCollection", geom.NewGeometryCollection().MustPush(
+				geom.NewPointFlat(geom.XY, []float64{bad, 2}))},
+		} {
+			t.Run(nonFinite.name+"/"+tc.name, func(t *testing.T) {
+				s, err := Marshal(tc.g)
+				t.Logf("got string=%q err=%v", s, err)
+				assert.Error(t, err)
+				var nonFiniteErr ErrNonFiniteCoord
+				assert.True(t, asNonFinite(err, &nonFiniteErr),
+					"want ErrNonFiniteCoord, got %T: %v", err, err)
+				assert.Equal(t, "", s)
+			})
+		}
+	}
+}
+
+// TestMarshalFiniteUnaffected proves the guard does not over-reject: finite
+// ordinates, including edge magnitudes, still marshal without error and
+// round-trip through the decoder unchanged.
+func TestMarshalFiniteUnaffected(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		g    geom.T
+		want string // exact expected string, "" to skip the exact check
+	}{
+		{"zero", geom.NewPointFlat(geom.XY, []float64{0, 0}), "POINT (0 0)"},
+		{"negative", geom.NewPointFlat(geom.XY, []float64{-1.5, -2}), "POINT (-1.5 -2)"},
+		{"veryLarge", geom.NewPointFlat(geom.XY, []float64{1e300, 2}), ""},
+		{"subnormal", geom.NewPointFlat(geom.XY, []float64{5e-324, 1}), ""},
+		{"lineString", geom.NewLineStringFlat(geom.XY, []float64{1, 2, 3, 4}),
+			"LINESTRING (1 2, 3 4)"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Marshal(tc.g)
+			t.Logf("want=%q got=%q err=%v", tc.want, got, err)
+			assert.NoError(t, err)
+			if tc.want != "" {
+				assert.Equal(t, tc.want, got)
+			}
+			back, err := Unmarshal(got)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.g, back)
+		})
+	}
+}
+
+// TestMarshalEmptyUnaffected confirms empty geometries stay on the writeEMPTY
+// path and never reach the writeCoord finite check.
+func TestMarshalEmptyUnaffected(t *testing.T) {
+	for _, tc := range []struct {
+		g    geom.T
+		want string
+	}{
+		{geom.NewPointEmpty(geom.XY), "POINT EMPTY"},
+		{geom.NewLineString(geom.XY), "LINESTRING EMPTY"},
+		{geom.NewPolygon(geom.XY), "POLYGON EMPTY"},
+		{geom.NewMultiPoint(geom.XY), "MULTIPOINT EMPTY"},
+		{geom.NewGeometryCollection(), "GEOMETRYCOLLECTION EMPTY"},
+	} {
+		got, err := Marshal(tc.g)
+		t.Logf("want=%q got=%q err=%v", tc.want, got, err)
+		assert.NoError(t, err)
+		assert.Equal(t, tc.want, got)
+	}
+}
+
+// asNonFinite reports whether err is an ErrNonFiniteCoord, storing it in target.
+func asNonFinite(err error, target *ErrNonFiniteCoord) bool {
+	e, ok := err.(ErrNonFiniteCoord)
+	if ok {
+		*target = e
+	}
+	return ok
+}

--- a/encoding/wkt/wkt.go
+++ b/encoding/wkt/wkt.go
@@ -8,6 +8,7 @@ package wkt
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/twpayne/go-geom"
 )
@@ -28,6 +29,16 @@ const (
 
 // ErrBraceMismatch is returned when braces do not match.
 var ErrBraceMismatch = errors.New("wkt: brace mismatch")
+
+// An ErrNonFiniteCoord is returned when encoding a coordinate whose ordinate is
+// not finite (NaN or ±Inf), which WKT cannot represent.
+type ErrNonFiniteCoord struct {
+	Value float64
+}
+
+func (e ErrNonFiniteCoord) Error() string {
+	return fmt.Sprintf("wkt: cannot encode non-finite coordinate %v", e.Value)
+}
 
 // Encoder encodes WKT based on specified parameters.
 type Encoder struct {


### PR DESCRIPTION
### Problem

The WKT encoder formats every coordinate ordinate unconditionally:

```go
coordStr := strconv.FormatFloat(x, 'f', e.maxDecimalDigits, 64)
```

For a non-finite ordinate (`NaN`, `+Inf`, `-Inf`) this appends the Go tokens `NaN` / `+Inf` / `-Inf` into the output and returns no error. WKT has no representation for those values, and this package's **own** decoder rejects them, so `Marshal` produces a string it cannot read back:

```go
pt := geom.NewPointFlat(geom.XY, []float64{math.NaN(), 2})
s, _ := wkt.Marshal(pt)      // "POINT (NaN 2)", no error
_, err := wkt.Unmarshal(s)   // syntax error: invalid keyword at line 1, pos 7
```

Every geometry type routes through `writeCoord`, so all of them are affected:

```
Point       "POINT (NaN 2)"                      -> invalid keyword pos 7
LineString  "LINESTRING (NaN 2, 3 4)"            -> invalid keyword pos 12
Polygon     "POLYGON ((NaN 0, 1 0, 1 1, NaN 0))" -> invalid keyword pos 10
MultiPoint  "MULTIPOINT (NaN 2, 3 4)"            -> invalid keyword pos 12
```

### Fix

`writeCoord` now returns an error for any non-finite ordinate rather than emitting output the decoder rejects. This is the single root cause, so the one guard covers every geometry type (Point, LineString, LinearRing, Polygon, MultiPoint, MultiLineString, MultiPolygon, GeometryCollection) and every layout (XY/XYZ/XYM/XYZM). It mirrors what the GeoJSON path already does — `json.Marshal` errors on non-finite floats — and what `encoding/json` does in the standard library.

`Marshal`/`Encode`/`writeCoord` already return `error`, and `Encode` discards the builder on error, so this is not an API change and no partial/invalid string is emitted.

Scope is deliberately narrow:

- Only `NaN`/`±Inf` are rejected; every finite value (including `0`, negatives, `1e300`, and subnormals) still encodes exactly as before and round-trips.
- EMPTY geometries are detected upstream and routed to `writeEMPTY`; they never reach `writeCoord` and are unaffected.
- WKB byte encoding is untouched.

One judgement call worth flagging: an all-`NaN` point (`[NaN, NaN]`) was historically discussed as a WKB empty-point convention, but `wkb.Marshal` on an empty point currently errors rather than emitting `[NaN, NaN]`, so that convention is not live here and erroring is consistent. If you'd prefer an all-`NaN` coordinate to map to `EMPTY` instead, happy to adjust.

### Tests

`encoding/wkt/encode_nonfinite_test.go`:

- `TestMarshalNonFiniteCoord` — NaN/+Inf/-Inf across all geometry types and layouts; asserts `ErrNonFiniteCoord` and an empty result string.
- `TestMarshalFiniteUnaffected` — finite matrix (zero, negative, `1e300`, subnormal) still marshals without error and round-trips.
- `TestMarshalEmptyUnaffected` — EMPTY geometries still emit `... EMPTY`.

Full suite passes; `gofmt` and `go vet` clean.
